### PR TITLE
research: Add Y.Text and XML types integration

### DIFF
--- a/examples/06_ytext/README.md
+++ b/examples/06_ytext/README.md
@@ -1,0 +1,148 @@
+# Y.Text Collaborative Editor Example
+
+A minimal example demonstrating character-level collaborative text editing with Y.Text.
+
+## What You'll Learn
+
+This example showcases:
+
+- 📝 **Y.Text CRDT**: Character-level collaborative text editing
+- ⌨️ **Simultaneous Editing**: Multiple users can type at the same time
+- 🔄 **Character Merging**: Changes merge at the character level, not by replacing entire strings
+- 🔴 **Offline Support**: Changes sync when clients come back online
+- ⚛️ **React Integration**: Use Y.Text with valtio-y in React
+
+## Why Y.Text?
+
+### Problem with Plain Strings
+
+When using plain JavaScript strings in collaborative editing:
+
+```tsx
+// Client 1
+text = "Hello";
+
+// Client 2 (simultaneously)
+text = "World";
+
+// Result: One completely overwrites the other ❌
+// Final state: Either "Hello" OR "World"
+```
+
+### Solution with Y.Text
+
+Y.Text is a CRDT that tracks each character individually:
+
+```tsx
+// Client 1
+ytext.insert(0, "Hello");
+
+// Client 2 (simultaneously)
+ytext.insert(0, "World");
+
+// Result: Both edits merge intelligently ✅
+// Final state: "WorldHello" or "HelloWorld" (deterministic based on timestamps)
+```
+
+## Key Features
+
+### Character-Level Operations
+
+Instead of replacing the entire text, Y.Text uses granular operations:
+
+```tsx
+// Insert characters
+stateProxy.sharedText.insert(position, "text");
+
+// Delete characters
+stateProxy.sharedText.delete(position, length);
+
+// Read as string
+const content = snap.sharedText.toString();
+```
+
+### Intelligent Merging
+
+When multiple clients edit simultaneously:
+1. Y.Text assigns each character a unique identity
+2. Changes are tracked with logical timestamps
+3. Edits merge without conflicts using CRDT algorithms
+4. All clients converge to the same final state
+
+## Running the Example
+
+```bash
+# Install dependencies (from the workspace root)
+pnpm install
+
+# Start the dev server
+cd examples/06_ytext
+pnpm dev
+```
+
+## Try This
+
+1. **Simultaneous Typing**: Type in both editors at the same time and watch the characters merge
+2. **Offline Editing**: Make both clients offline, type different text in each, then bring them online
+3. **Conflict Resolution**: Edit the same position in both clients while one is offline
+4. **Character Preservation**: Unlike string replacement, individual characters are preserved and merged
+
+## Implementation Details
+
+### Text Change Detection
+
+The example implements efficient change detection:
+
+```tsx
+const handleTextChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+  const newValue = e.target.value;
+  const oldValue = stateProxy.sharedText.toString();
+  
+  // Calculate minimal operations (insert/delete) instead of replacing entire text
+  if (newValue.length > oldValue.length) {
+    // Insert
+    stateProxy.sharedText.insert(position, insertedText);
+  } else if (newValue.length < oldValue.length) {
+    // Delete
+    stateProxy.sharedText.delete(position, deleteCount);
+  }
+};
+```
+
+### Y.Text vs Strings
+
+| Feature | Plain String | Y.Text |
+|---------|-------------|--------|
+| Collaborative editing | ❌ Last write wins | ✅ Character-level merge |
+| Conflict resolution | ❌ Overwrites | ✅ Deterministic merging |
+| Simultaneous edits | ❌ One edit lost | ✅ Both preserved |
+| Performance | ⚡ Simple | ⚡ Optimized for collaboration |
+
+## When to Use Y.Text
+
+Use Y.Text when:
+- Multiple users need to edit text simultaneously
+- You need real-time collaborative text editing
+- Preserving all edits is important
+- You want Google Docs-style collaboration
+
+Use plain strings when:
+- Only one user edits at a time
+- Last-write-wins is acceptable
+- Simple form fields without collaboration
+- The text is replaced entirely on each edit
+
+## Next Steps
+
+After understanding Y.Text, you can:
+1. Add cursor position tracking for multi-user awareness
+2. Implement rich text formatting with `Y.XmlFragment`
+3. Add undo/redo with Yjs's built-in history
+4. Build a full collaborative text editor with syntax highlighting
+5. Connect to a real network provider for production use
+
+## Related Examples
+
+- **05_todos_simple**: Shows plain strings for simple data (recommended for non-text fields)
+- **04_todos**: Complex example with nested structures
+- Check valtio-y docs for more Y.Text features and options

--- a/examples/06_ytext/index.html
+++ b/examples/06_ytext/index.html
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <title>Y.Text Example - Valtio-Yjs</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/06_ytext/package.json
+++ b/examples/06_ytext/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "example-ytext",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "react": "latest",
+    "react-dom": "latest",
+    "valtio": "latest",
+    "valtio-y": "workspace:*",
+    "yjs": "latest"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.1.14",
+    "@types/react": "latest",
+    "@types/react-dom": "latest",
+    "@vitejs/plugin-react": "latest",
+    "autoprefixer": "^10.4.21",
+    "postcss": "^8.5.6",
+    "tailwindcss": "^4.1.14",
+    "typescript": "latest",
+    "vite": "latest"
+  },
+  "scripts": {
+    "dev": "vite",
+    "typecheck": "tsc --noEmit"
+  }
+}

--- a/examples/06_ytext/src/app.tsx
+++ b/examples/06_ytext/src/app.tsx
@@ -1,0 +1,392 @@
+/**
+ * Y.Text Collaborative Editing Example
+ *
+ * This example demonstrates character-level collaborative text editing with Y.Text:
+ *
+ * 1. **Y.Text**: Yjs's CRDT for text that supports character-level merging
+ * 2. **Conflict-Free Editing**: Multiple users can edit the same text simultaneously
+ * 3. **Offline Support**: Changes sync when coming back online
+ * 4. **Character Preservation**: Unlike string replacement, Y.Text merges edits character-by-character
+ */
+
+import { useSnapshot } from "valtio";
+import * as Y from "yjs";
+import { createYjsProxy, syncedText } from "valtio-y";
+import { useState, useEffect, useRef } from "react";
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+type AppState = {
+  sharedText: Y.Text;
+};
+
+// ============================================================================
+// YJS SETUP
+// ============================================================================
+
+// Create two Y.Docs to simulate two clients
+const doc1 = new Y.Doc();
+const doc2 = new Y.Doc();
+
+const RELAY_ORIGIN = Symbol("relay");
+
+// Track online/offline status
+let client1Online = true;
+let client2Online = true;
+
+const client1Queue: Uint8Array[] = [];
+const client2Queue: Uint8Array[] = [];
+
+const statusListeners = new Set<() => void>();
+
+function notifyStatusChange() {
+  statusListeners.forEach((listener) => listener());
+}
+
+export function toggleClient1Online() {
+  client1Online = !client1Online;
+  if (client1Online) {
+    client1Queue.forEach((update) => {
+      setTimeout(() => {
+        doc2.transact(() => Y.applyUpdate(doc2, update), RELAY_ORIGIN);
+      }, 50);
+    });
+    client1Queue.length = 0;
+
+    if (client2Online && client2Queue.length > 0) {
+      client2Queue.forEach((update) => {
+        setTimeout(() => {
+          doc1.transact(() => Y.applyUpdate(doc1, update), RELAY_ORIGIN);
+        }, 50);
+      });
+      client2Queue.length = 0;
+    }
+  }
+  notifyStatusChange();
+}
+
+export function toggleClient2Online() {
+  client2Online = !client2Online;
+  if (client2Online) {
+    client2Queue.forEach((update) => {
+      setTimeout(() => {
+        doc1.transact(() => Y.applyUpdate(doc1, update), RELAY_ORIGIN);
+      }, 50);
+    });
+    client2Queue.length = 0;
+
+    if (client1Online && client1Queue.length > 0) {
+      client1Queue.forEach((update) => {
+        setTimeout(() => {
+          doc2.transact(() => Y.applyUpdate(doc2, update), RELAY_ORIGIN);
+        }, 50);
+      });
+      client1Queue.length = 0;
+    }
+  }
+  notifyStatusChange();
+}
+
+export function subscribeToStatus(listener: () => void): () => void {
+  statusListeners.add(listener);
+  return () => {
+    statusListeners.delete(listener);
+  };
+}
+
+export function getClient1Online() {
+  return client1Online;
+}
+
+export function getClient2Online() {
+  return client2Online;
+}
+
+doc1.on("update", (update: Uint8Array, origin: unknown) => {
+  if (origin === RELAY_ORIGIN) return;
+
+  if (client1Online) {
+    setTimeout(() => {
+      doc2.transact(() => Y.applyUpdate(doc2, update), RELAY_ORIGIN);
+    }, 50);
+  } else {
+    client1Queue.push(update);
+  }
+});
+
+doc2.on("update", (update: Uint8Array, origin: unknown) => {
+  if (origin === RELAY_ORIGIN) return;
+
+  if (client2Online) {
+    setTimeout(() => {
+      doc1.transact(() => Y.applyUpdate(doc1, update), RELAY_ORIGIN);
+    }, 50);
+  } else {
+    client2Queue.push(update);
+  }
+});
+
+// Create valtio-y proxies
+const { proxy: proxy1, bootstrap: bootstrap1 } = createYjsProxy<AppState>(
+  doc1,
+  {
+    getRoot: (doc) => doc.getMap("sharedState"),
+  },
+);
+
+const { proxy: proxy2 } = createYjsProxy<AppState>(doc2, {
+  getRoot: (doc) => doc.getMap("sharedState"),
+});
+
+// Initialize with sample text - use bootstrap to ensure proper initialization
+bootstrap1({
+  sharedText: syncedText(
+    "Start typing here! Try editing from both clients at the same time.",
+  ),
+});
+
+// ============================================================================
+// CLIENT VIEW COMPONENT
+// ============================================================================
+
+type ClientViewProps = {
+  name: string;
+  stateProxy: AppState;
+  color: string;
+  clientId: 1 | 2;
+};
+
+function ClientView({ name, stateProxy, color, clientId }: ClientViewProps) {
+  const snap = useSnapshot(stateProxy);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [isOnline, setIsOnline] = useState(
+    clientId === 1 ? getClient1Online() : getClient2Online(),
+  );
+  const cursorPositionRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    const unsubscribe = subscribeToStatus(() => {
+      setIsOnline(clientId === 1 ? getClient1Online() : getClient2Online());
+    });
+    return unsubscribe;
+  }, [clientId]);
+
+  // Get text content (safe even if sharedText is undefined)
+  const textContent = snap.sharedText?.toString() || "";
+
+  // Restore cursor position after re-render from remote changes
+  useEffect(() => {
+    if (cursorPositionRef.current !== null && textareaRef.current) {
+      const pos = cursorPositionRef.current;
+      textareaRef.current.setSelectionRange(pos, pos);
+      cursorPositionRef.current = null;
+    }
+  }, [textContent]);
+
+  // Safety check: ensure sharedText exists (after all hooks)
+  if (!snap.sharedText) {
+    return (
+      <div className="flex-1 rounded-xl shadow-lg border-2 p-6 bg-white border-slate-200">
+        <p className="text-slate-500">Initializing...</p>
+      </div>
+    );
+  }
+
+  const handleToggleOnline = () => {
+    if (clientId === 1) {
+      toggleClient1Online();
+    } else {
+      toggleClient2Online();
+    }
+  };
+
+  const handleTextChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const newValue = e.target.value;
+    const oldValue = stateProxy.sharedText.toString();
+    const textarea = textareaRef.current;
+
+    if (!textarea) return;
+
+    // Skip if values are the same (shouldn't happen but defensive)
+    if (newValue === oldValue) {
+      return;
+    }
+
+    const cursorPos = textarea.selectionStart;
+
+    // Calculate the diff and apply minimal changes to Y.Text
+    if (newValue.length > oldValue.length) {
+      // Text was inserted
+      const inserted = newValue.substring(
+        cursorPos - (newValue.length - oldValue.length),
+        cursorPos,
+      );
+      const insertPos = cursorPos - inserted.length;
+      stateProxy.sharedText.insert(insertPos, inserted);
+      // Save cursor position to restore after re-render
+      cursorPositionRef.current = cursorPos;
+    } else if (newValue.length < oldValue.length) {
+      // Text was deleted
+      const deleteCount = oldValue.length - newValue.length;
+      stateProxy.sharedText.delete(cursorPos, deleteCount);
+      // Save cursor position to restore after re-render
+      cursorPositionRef.current = cursorPos;
+    } else {
+      // Text was replaced (same length) - delete and insert
+      const diffStart = Array.from(oldValue).findIndex(
+        (char, i) => char !== newValue[i],
+      );
+      if (diffStart !== -1 && diffStart < newValue.length) {
+        stateProxy.sharedText.delete(diffStart, 1);
+        stateProxy.sharedText.insert(diffStart, newValue[diffStart]!);
+        cursorPositionRef.current = cursorPos;
+      }
+    }
+  };
+
+  const charCount = textContent.length;
+  const wordCount = textContent.trim()
+    ? textContent.trim().split(/\s+/).length
+    : 0;
+
+  return (
+    <div
+      className={`flex-1 rounded-xl shadow-lg border-2 p-6 transition-all ${
+        isOnline
+          ? "bg-white border-slate-200"
+          : "bg-slate-100 border-orange-300"
+      }`}
+    >
+      {/* Header */}
+      <div className="mb-4">
+        <div className="flex items-center justify-between mb-3">
+          <div
+            className={`inline-block px-3 py-1 rounded-full text-sm font-semibold bg-${color}-100 text-${color}-700`}
+          >
+            {name}
+          </div>
+          <button
+            onClick={handleToggleOnline}
+            className={`px-4 py-2 rounded-lg font-medium transition-all ${
+              isOnline
+                ? "bg-green-100 text-green-700 hover:bg-green-200"
+                : "bg-orange-100 text-orange-700 hover:bg-orange-200"
+            }`}
+          >
+            {isOnline ? "🟢 Online" : "🔴 Offline"}
+          </button>
+        </div>
+        <h2 className="text-2xl font-bold text-slate-900 mb-1">
+          Shared Editor
+        </h2>
+        <p className="text-sm text-slate-600">
+          {charCount} characters · {wordCount} words
+          {!isOnline && " · Working offline"}
+        </p>
+      </div>
+
+      {/* Text Editor */}
+      <textarea
+        ref={textareaRef}
+        value={textContent}
+        onChange={handleTextChange}
+        className="w-full h-64 px-4 py-3 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none font-mono text-sm"
+        placeholder="Start typing..."
+      />
+
+      {/* Info */}
+      <div className="mt-3 text-xs text-slate-500">
+        💡 Try typing in both editors simultaneously to see character-level
+        merging
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// MAIN APP
+// ============================================================================
+
+const App = () => {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 py-8 px-4">
+      <div className="max-w-6xl mx-auto">
+        {/* Header */}
+        <div className="text-center mb-8">
+          <h1 className="text-4xl font-bold text-slate-900 mb-3">
+            Y.Text Collaborative Editor
+          </h1>
+          <p className="text-slate-600 mb-2">
+            Character-level collaborative text editing with{" "}
+            <strong>valtio-y</strong>
+          </p>
+          <div className="flex flex-wrap justify-center gap-4 text-sm text-slate-500">
+            <span>⌨️ Type in both editors simultaneously</span>
+            <span>✨ Watch character-level merging</span>
+            <span>🔴 Toggle offline to test sync</span>
+          </div>
+        </div>
+
+        {/* Two Clients Side by Side */}
+        <div className="grid md:grid-cols-2 gap-6 mb-8">
+          <ClientView
+            name="Client 1"
+            stateProxy={proxy1}
+            color="blue"
+            clientId={1}
+          />
+          <ClientView
+            name="Client 2"
+            stateProxy={proxy2}
+            color="purple"
+            clientId={2}
+          />
+        </div>
+
+        {/* Explanation */}
+        <div className="bg-white rounded-lg shadow-md border border-slate-200 p-6 max-w-3xl mx-auto">
+          <h3 className="text-lg font-semibold text-slate-900 mb-4">
+            Why Y.Text Instead of Strings?
+          </h3>
+          <div className="space-y-3 text-sm text-slate-600">
+            <div>
+              <strong className="text-slate-900">String Replacement:</strong>{" "}
+              When using plain strings, editing replaces the entire value. If
+              two clients edit at the same time, one edit overwrites the other.
+            </div>
+            <div>
+              <strong className="text-slate-900">Y.Text (CRDT):</strong> Y.Text
+              tracks every character with its own identity and position. When
+              two clients edit simultaneously, their changes merge at the
+              character level without conflicts.
+            </div>
+            <div className="pt-3 border-t border-slate-200">
+              <strong className="text-slate-900">Example:</strong>
+              <ul className="mt-2 ml-4 space-y-1 text-xs list-disc">
+                <li>Client 1 types &quot;Hello&quot; at position 0</li>
+                <li>
+                  Client 2 types &quot;World&quot; at position 0 (offline)
+                </li>
+                <li>
+                  When Client 2 comes online: Y.Text merges to
+                  &quot;WorldHello&quot; or &quot;HelloWorld&quot; depending on
+                  timestamps
+                </li>
+                <li>With strings: One would completely replace the other ❌</li>
+              </ul>
+            </div>
+          </div>
+          <div className="mt-4 pt-4 border-t border-slate-200 text-xs text-slate-500">
+            💡 <strong>Try this:</strong> Make both clients offline. Type
+            different text in each. Bring them back online and watch Y.Text
+            merge the changes intelligently!
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default App;

--- a/examples/06_ytext/src/main.tsx
+++ b/examples/06_ytext/src/main.tsx
@@ -1,0 +1,11 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+
+import "./styles.css";
+import App from "./app";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/examples/06_ytext/src/styles.css
+++ b/examples/06_ytext/src/styles.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/examples/06_ytext/tsconfig.json
+++ b/examples/06_ytext/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"]
+  }
+}

--- a/examples/06_ytext/vite.config.ts
+++ b/examples/06_ytext/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+
+export default defineConfig({
+  plugins: [tailwindcss(), react()],
+});

--- a/valtio-y/src/bridge/leaf-computed.ts
+++ b/valtio-y/src/bridge/leaf-computed.ts
@@ -1,0 +1,166 @@
+// Leaf Node Reactivity via Computed Properties
+//
+// This approach uses computed properties (getters) instead of proxy wrappers.
+// When a component accesses snap.text, it calls the getter which:
+// 1. Touches the version counter (creating a Valtio dependency)
+// 2. Returns the underlying Y.js leaf node
+//
+// This works because Valtio tracks computed property accesses in snapshots.
+
+import type { YLeafType } from "../core/yjs-types";
+import type { ValtioYjsCoordinator } from "../core/coordinator";
+import { ref } from "valtio/vanilla";
+
+/**
+ * String property used to store/access the version counter for dependency tracking
+ * IMPORTANT: Must be a string property, NOT a symbol, because Valtio only tracks
+ * string properties for dependencies in snapshots.
+ */
+export const LEAF_VERSION_KEY = "__valtio_yjs_version";
+
+/**
+ * Creates a reactive wrapper around a Y.js leaf node that automatically
+ * touches the version counter on every property/method access.
+ * This ensures Valtio tracks the dependency without requiring explicit version access.
+ */
+function createReactiveLeafWrapper(
+  leafNode: YLeafType,
+  objProxy: Record<string | symbol, unknown>,
+): YLeafType {
+  return new Proxy(leafNode, {
+    get(target, prop, receiver) {
+      // Touch the version counter on EVERY access to the leaf node
+      // This creates a Valtio dependency automatically when methods like
+      // toString(), length, etc. are accessed from a snapshot
+      void objProxy[LEAF_VERSION_KEY];
+
+      const value = Reflect.get(target, prop, receiver);
+
+      // If the value is a function, bind it to the original target
+      if (typeof value === "function") {
+        return value.bind(target);
+      }
+
+      return value;
+    },
+  }) as YLeafType;
+}
+
+/**
+ * Sets up a Y.js leaf node with automatic reactivity using a computed property.
+ *
+ * Instead of wrapping the leaf node in a proxy, we:
+ * 1. Store the leaf node in a symbol property
+ * 2. Define a getter that touches the version counter before returning the leaf
+ * 3. Set up an observer that increments the version counter on changes
+ *
+ * This ensures that when a component accesses `snap.text`, it creates a dependency
+ * on the version counter, causing re-renders when the Y.js content changes.
+ *
+ * @param context - Synchronization context for lock management and cleanup
+ * @param objProxy - The Valtio proxy object to attach the leaf to
+ * @param key - The property key where the leaf should be accessible
+ * @param leafNode - The Y.js leaf type (Y.Text, Y.XmlText, etc.)
+ */
+export function setupLeafNodeAsComputed(
+  coordinator: ValtioYjsCoordinator,
+  objProxy: Record<string | symbol, unknown>,
+  key: string,
+  leafNode: YLeafType,
+): void {
+  // Initialize version counter if it doesn't exist
+  if (!(LEAF_VERSION_KEY in objProxy)) {
+    objProxy[LEAF_VERSION_KEY] = 0;
+  }
+
+  // Create a reactive wrapper that touches version counter on every access
+  const reactiveLeaf = createReactiveLeafWrapper(leafNode, objProxy);
+
+  // Store the reactive wrapper in a symbol property (ref'd to prevent deep proxying)
+  const storageKey = Symbol.for(`valtio-y:leaf:${key}`);
+  objProxy[storageKey] = ref(reactiveLeaf);
+
+  // Define a computed property (getter) that returns the reactive wrapper
+  Object.defineProperty(objProxy, key, {
+    get(this: typeof objProxy) {
+      // The reactive wrapper will touch the version counter on every access
+      // to its properties/methods, so components don't need explicit version access
+      return this[storageKey];
+    },
+    enumerable: true,
+    configurable: true,
+  });
+
+  // Set up Y.js observer to increment version counter on changes
+  const handler = () => {
+    // Increment the version counter - this is a tracked property so it will
+    // notify all subscribers (including React components using useSnapshot)
+    const currentVersion = objProxy[LEAF_VERSION_KEY] as number;
+    objProxy[LEAF_VERSION_KEY] = currentVersion + 1;
+  };
+
+  leafNode.observe(handler);
+
+  // Register cleanup
+  coordinator.registerDisposable(() => {
+    leafNode.unobserve(handler);
+  });
+
+  coordinator.logger.debug(
+    "[leaf-computed] setup complete (with reactive wrapper)",
+    {
+      key,
+      type: leafNode.constructor.name,
+    },
+  );
+}
+
+/**
+ * Array version of setupLeafNodeAsComputed
+ */
+export function setupLeafNodeAsComputedInArray(
+  coordinator: ValtioYjsCoordinator,
+  arrProxy: unknown[],
+  index: number,
+  leafNode: YLeafType,
+): void {
+  // For arrays, we can't use computed properties on indices (they're not stable)
+  // So we store the ref'd leaf directly and use a version counter on the array
+  const arrAsRecord = arrProxy as unknown as Record<string, unknown>;
+
+  // Initialize version counter on the array
+  if (!(LEAF_VERSION_KEY in arrAsRecord)) {
+    arrAsRecord[LEAF_VERSION_KEY] = 0;
+  }
+
+  // Store the ref'd leaf directly in the array
+  arrProxy[index] = ref(leafNode);
+
+  // Set up observer to increment the array's version counter
+  const handler = () => {
+    const currentVersion = arrAsRecord[LEAF_VERSION_KEY] as number;
+    arrAsRecord[LEAF_VERSION_KEY] = currentVersion + 1;
+  };
+
+  leafNode.observe(handler);
+
+  coordinator.registerDisposable(() => {
+    leafNode.unobserve(handler);
+  });
+
+  coordinator.logger.debug("[leaf-computed] setup complete (array)", {
+    index,
+    type: leafNode.constructor.name,
+  });
+}
+
+/**
+ * Gets the underlying Y.js leaf node from a proxy
+ */
+export function getUnderlyingLeaf(
+  obj: Record<string | symbol, unknown>,
+  key: string,
+): YLeafType | undefined {
+  const storageKey = Symbol.for(`valtio-y:leaf:${key}`);
+  return obj[storageKey] as YLeafType | undefined;
+}

--- a/valtio-y/src/core/guards.test.ts
+++ b/valtio-y/src/core/guards.test.ts
@@ -5,6 +5,7 @@ import * as Y from "yjs";
 import {
   isYMap,
   isYArray,
+  isYText,
   isYSharedContainer,
   isYAbstractType,
 } from "./guards";
@@ -19,6 +20,11 @@ describe("Type Guards", () => {
     it("returns false for Y.Array instances", () => {
       const yArr = new Y.Array();
       expect(isYMap(yArr)).toBe(false);
+    });
+
+    it("returns false for Y.Text instances", () => {
+      const yText = new Y.Text();
+      expect(isYMap(yText)).toBe(false);
     });
 
     it("returns false for plain objects", () => {
@@ -54,6 +60,11 @@ describe("Type Guards", () => {
       expect(isYArray(yMap)).toBe(false);
     });
 
+    it("returns false for Y.Text instances", () => {
+      const yText = new Y.Text();
+      expect(isYArray(yText)).toBe(false);
+    });
+
     it("returns false for plain arrays", () => {
       expect(isYArray([])).toBe(false);
       expect(isYArray([1, 2, 3])).toBe(false);
@@ -70,6 +81,43 @@ describe("Type Guards", () => {
     });
   });
 
+  describe("isYText()", () => {
+    it("returns true for Y.Text instances", () => {
+      const yText = new Y.Text();
+      expect(isYText(yText)).toBe(true);
+    });
+
+    it("returns true for Y.Text with content", () => {
+      const yText = new Y.Text("hello");
+      expect(isYText(yText)).toBe(true);
+    });
+
+    it("returns false for Y.Map instances", () => {
+      const yMap = new Y.Map();
+      expect(isYText(yMap)).toBe(false);
+    });
+
+    it("returns false for Y.Array instances", () => {
+      const yArr = new Y.Array();
+      expect(isYText(yArr)).toBe(false);
+    });
+
+    it("returns false for strings", () => {
+      expect(isYText("hello")).toBe(false);
+      expect(isYText("")).toBe(false);
+    });
+
+    it("returns false for null and undefined", () => {
+      expect(isYText(null)).toBe(false);
+      expect(isYText(undefined)).toBe(false);
+    });
+
+    it("returns false for objects with toString method", () => {
+      const obj = { toString: () => "hello" };
+      expect(isYText(obj)).toBe(false);
+    });
+  });
+
   describe("isYSharedContainer()", () => {
     it("returns true for Y.Map instances", () => {
       const yMap = new Y.Map();
@@ -79,6 +127,11 @@ describe("Type Guards", () => {
     it("returns true for Y.Array instances", () => {
       const yArr = new Y.Array();
       expect(isYSharedContainer(yArr)).toBe(true);
+    });
+
+    it("returns false for Y.Text instances", () => {
+      const yText = new Y.Text();
+      expect(isYSharedContainer(yText)).toBe(false);
     });
 
     it("returns false for plain objects and arrays", () => {
@@ -101,6 +154,11 @@ describe("Type Guards", () => {
     it("returns true for Y.Array instances", () => {
       const yArr = new Y.Array();
       expect(isYAbstractType(yArr)).toBe(true);
+    });
+
+    it("returns true for Y.Text instances", () => {
+      const yText = new Y.Text();
+      expect(isYAbstractType(yText)).toBe(true);
     });
 
     it("returns false for plain objects and arrays", () => {
@@ -140,18 +198,32 @@ describe("Type Guards", () => {
       expect(isYSharedContainer(retrieved)).toBe(true);
     });
 
+    it("handles Y.Text in structures", () => {
+      const doc = new Y.Doc();
+      const yMap = doc.getMap("map");
+      const yText = new Y.Text("content");
+      yMap.set("text", yText);
+
+      const retrieved = yMap.get("text");
+      expect(isYText(retrieved)).toBe(true);
+      expect(isYAbstractType(retrieved)).toBe(true);
+      expect(isYSharedContainer(retrieved)).toBe(false);
+    });
+
     it("correctly identifies different types in mixed array", () => {
       const doc = new Y.Doc();
       const yArr = doc.getArray("arr");
       const yMap = new Y.Map();
+      const yText = new Y.Text();
       const yNestedArr = new Y.Array();
 
-      yArr.insert(0, [yMap, yNestedArr, "string", 42]);
+      yArr.insert(0, [yMap, yText, yNestedArr, "string", 42]);
 
       expect(isYMap(yArr.get(0))).toBe(true);
-      expect(isYArray(yArr.get(1))).toBe(true);
-      expect(isYMap(yArr.get(2))).toBe(false);
+      expect(isYText(yArr.get(1))).toBe(true);
+      expect(isYArray(yArr.get(2))).toBe(true);
       expect(isYMap(yArr.get(3))).toBe(false);
+      expect(isYMap(yArr.get(4))).toBe(false);
     });
   });
 });

--- a/valtio-y/src/core/guards.ts
+++ b/valtio-y/src/core/guards.ts
@@ -1,8 +1,12 @@
 import * as Y from "yjs";
-import type { YSharedContainer } from "./yjs-types";
+import type { YSharedContainer, YLeafType } from "./yjs-types";
 
 export function isYSharedContainer(value: unknown): value is YSharedContainer {
   return value instanceof Y.Map || value instanceof Y.Array;
+  // Note: Y.XmlFragment, Y.XmlElement, and Y.XmlHook are treated as leaf types,
+  // not containers, even though they have container-like APIs. This is because
+  // they need to preserve their native Y.js methods and shouldn't be wrapped in
+  // Valtio proxies. See isYLeafType() for the complete list of leaf types.
 }
 
 export function isYMap(value: unknown): value is Y.Map<unknown> {
@@ -13,8 +17,62 @@ export function isYArray(value: unknown): value is Y.Array<unknown> {
   return value instanceof Y.Array;
 }
 
+export function isYText(value: unknown): value is Y.Text {
+  return value instanceof Y.Text;
+}
+
+export function isYXmlFragment(value: unknown): value is Y.XmlFragment {
+  return value instanceof Y.XmlFragment;
+}
+
+export function isYXmlElement(value: unknown): value is Y.XmlElement {
+  return value instanceof Y.XmlElement;
+}
+
+export function isYXmlHook(value: unknown): value is Y.XmlHook {
+  return value instanceof Y.XmlHook;
+}
+
 export function isYAbstractType(
   value: unknown,
 ): value is Y.AbstractType<unknown> {
   return value instanceof Y.AbstractType;
+}
+
+/**
+ * Checks if a value is a Y.js leaf type (non-container CRDT).
+ * Leaf types have internal CRDT state and should not be deeply proxied.
+ * They are stored as-is (wrapped in ref()) rather than being proxied.
+ *
+ * Currently supports:
+ * - Y.Text: Collaborative text CRDT
+ * - Y.XmlText: XML-specific text (extends Y.Text)
+ * - Y.XmlFragment: XML container with array-like interface
+ * - Y.XmlElement: XML element with attributes + children
+ * - Y.XmlHook: Custom hook type (extends Y.Map)
+ *
+ * Note: Y.XmlText extends Y.Text, so instanceof Y.Text catches both.
+ *
+ * XML types (XmlFragment, XmlElement, XmlHook) are treated as leaf types because:
+ * - They have their own native interfaces that shouldn't be wrapped
+ * - They need to preserve their Y.js methods (insert, setAttribute, etc.)
+ * - Proxying them would break their specialized APIs
+ *
+ * To add more leaf types:
+ * 1. Add instanceof check here (e.g., || value instanceof Y.SomeLeafType)
+ * 2. Add tests in tests/e2e/ to verify convergence and reactivity
+ * 3. Update README.md to document the new leaf type
+ *
+ * Future leaf types to consider:
+ * - Custom Y.AbstractType implementations with specialized APIs
+ */
+export function isYLeafType(value: unknown): value is YLeafType {
+  // Y.Text includes Y.XmlText since it extends Y.Text
+  // XML types are treated as leaf types to preserve their native APIs
+  return (
+    value instanceof Y.Text ||
+    value instanceof Y.XmlFragment ||
+    value instanceof Y.XmlElement ||
+    value instanceof Y.XmlHook
+  );
 }

--- a/valtio-y/src/core/yjs-types.ts
+++ b/valtio-y/src/core/yjs-types.ts
@@ -1,7 +1,23 @@
 import * as Y from "yjs";
 
 // Shared Yjs container types that are deeply proxied by Valtio
+// Note: Y.XmlFragment, Y.XmlElement, and Y.XmlHook are NOT included here
+// because they are treated as leaf types to preserve their native Y.js APIs.
 export type YSharedContainer = Y.Map<unknown> | Y.Array<unknown>;
+
+/**
+ * Y.js leaf types that should not be deeply proxied by Valtio.
+ *
+ * Leaf types have internal CRDT state and native Y.js methods that must be preserved.
+ * They are wrapped in ref() to prevent deep proxying and observed for changes instead.
+ *
+ * Supported leaf types:
+ * - Y.Text: Collaborative text CRDT (includes Y.XmlText which extends Y.Text)
+ * - Y.XmlFragment: XML container with array-like interface
+ * - Y.XmlElement: XML element with attributes + children
+ * - Y.XmlHook: Custom hook type (extends Y.Map)
+ */
+export type YLeafType = Y.Text | Y.XmlFragment | Y.XmlElement | Y.XmlHook;
 
 // Event-related types used with observeDeep
 export type YArrayDelta = Array<{

--- a/valtio-y/src/index.ts
+++ b/valtio-y/src/index.ts
@@ -11,6 +11,9 @@ export type { CreateYjsProxyOptions, YjsProxy } from "./create-yjs-proxy";
 // Constants
 export { VALTIO_YJS_ORIGIN } from "./core/constants";
 
+// Synced types
+export { syncedText } from "./synced-types";
+
 // Type utilities for advanced users
 export type {
   ValtioProxy,

--- a/valtio-y/src/synced-types.test.ts
+++ b/valtio-y/src/synced-types.test.ts
@@ -1,0 +1,124 @@
+/* eslint @typescript-eslint/no-explicit-any: "off" */
+
+import { describe, expect, it } from "vitest";
+import * as Y from "yjs";
+import { syncedText } from "./synced-types";
+
+describe("syncedText()", () => {
+  it("creates a Y.Text instance", () => {
+    const text = syncedText();
+    expect(text).toBeInstanceOf(Y.Text);
+  });
+
+  it("creates empty Y.Text when no initial content provided", () => {
+    const doc = new Y.Doc();
+    const text = syncedText();
+    // Y.Text needs to be attached to a document to be read
+    doc.getArray("test").insert(0, [text]);
+    expect(text.toString()).toBe("");
+    expect(text).toHaveLength(0);
+  });
+
+  it("creates Y.Text with initial content when provided", () => {
+    const doc = new Y.Doc();
+    const text = syncedText("Hello World");
+    // Y.Text needs to be attached to a document to be read
+    doc.getArray("test").insert(0, [text]);
+    expect(text.toString()).toBe("Hello World");
+    expect(text).toHaveLength(11);
+  });
+
+  it("creates Y.Text with empty string when explicitly provided", () => {
+    const doc = new Y.Doc();
+    const text = syncedText("");
+    doc.getArray("test").insert(0, [text]);
+    expect(text.toString()).toBe("");
+    expect(text).toHaveLength(0);
+  });
+
+  it("creates Y.Text with unicode content", () => {
+    const doc = new Y.Doc();
+    const content = "你好世界 🌍 émojis";
+    const text = syncedText(content);
+    doc.getArray("test").insert(0, [text]);
+    expect(text.toString()).toBe(content);
+  });
+
+  it("creates Y.Text with multiline content", () => {
+    const doc = new Y.Doc();
+    const content = "Line 1\nLine 2\nLine 3";
+    const text = syncedText(content);
+    doc.getArray("test").insert(0, [text]);
+    expect(text.toString()).toBe(content);
+  });
+
+  it("creates Y.Text with special characters", () => {
+    const doc = new Y.Doc();
+    const content = "Special: \t\n\r\b\f\v";
+    const text = syncedText(content);
+    doc.getArray("test").insert(0, [text]);
+    expect(text.toString()).toBe(content);
+  });
+
+  it("allows mutations on created Y.Text", () => {
+    const doc = new Y.Doc();
+    const text = syncedText("Hello");
+    doc.getArray("test").insert(0, [text]);
+    text.insert(5, " World");
+    expect(text.toString()).toBe("Hello World");
+  });
+
+  it("can be inserted into Y.Array", () => {
+    const doc = new Y.Doc();
+    const yArr = doc.getArray<Y.Text>("arr");
+    const text = syncedText("test content");
+
+    yArr.insert(0, [text]);
+    expect(yArr).toHaveLength(1);
+    expect(yArr.get(0)).toBeInstanceOf(Y.Text);
+    expect(yArr.get(0).toString()).toBe("test content");
+  });
+
+  it("can be set in Y.Map", () => {
+    const doc = new Y.Doc();
+    const yMap = doc.getMap<Y.Text>("map");
+    const text = syncedText("test content");
+
+    yMap.set("text", text);
+    expect(yMap.has("text")).toBe(true);
+    expect(yMap.get("text")).toBeInstanceOf(Y.Text);
+    expect(yMap.get("text")!.toString()).toBe("test content");
+  });
+
+  it("creates independent Y.Text instances", () => {
+    const doc = new Y.Doc();
+    const text1 = syncedText("text1");
+    const text2 = syncedText("text2");
+
+    // Attach both to the document
+    const arr = doc.getArray("test");
+    arr.insert(0, [text1, text2]);
+
+    expect(text1).not.toBe(text2);
+    expect(text1.toString()).toBe("text1");
+    expect(text2.toString()).toBe("text2");
+
+    text1.insert(5, " modified");
+    expect(text1.toString()).toBe("text1 modified");
+    expect(text2.toString()).toBe("text2"); // unaffected
+  });
+
+  it("can be used in nested structures", () => {
+    const doc = new Y.Doc();
+    const yRoot = doc.getMap("root");
+    const yContainer = new Y.Map();
+    const text = syncedText("nested text");
+
+    yContainer.set("text", text);
+    yRoot.set("container", yContainer);
+
+    const retrievedContainer = yRoot.get("container") as Y.Map<Y.Text>;
+    expect(retrievedContainer.get("text")).toBeInstanceOf(Y.Text);
+    expect(retrievedContainer.get("text")!.toString()).toBe("nested text");
+  });
+});

--- a/valtio-y/src/synced-types.ts
+++ b/valtio-y/src/synced-types.ts
@@ -1,0 +1,9 @@
+import * as Y from "yjs";
+
+/**
+ * Creates a collaborative text type. Use this in initial data
+ * to mark strings that should be collaboratively editable.
+ */
+export function syncedText(initialContent = ""): Y.Text {
+  return new Y.Text(initialContent);
+}

--- a/valtio-y/tests/e2e/e2e.xml-types.spec.ts
+++ b/valtio-y/tests/e2e/e2e.xml-types.spec.ts
@@ -1,0 +1,524 @@
+import { describe, it, expect } from "vitest";
+import * as Y from "yjs";
+import { subscribe } from "valtio/vanilla";
+import {
+  createRelayedProxiesMapRoot,
+  createRelayedProxiesArrayRoot,
+  waitMicrotask,
+} from "../helpers/test-helpers";
+
+describe("E2E: Y.Xml Types", () => {
+  describe("Y.XmlFragment", () => {
+    it("can create and sync Y.XmlFragment as a container", async () => {
+      const { proxyA, proxyB, bootstrapA } = createRelayedProxiesMapRoot();
+
+      // Create XmlFragment on A
+      const fragment = new Y.XmlFragment();
+      const element = new Y.XmlElement("div");
+      fragment.insert(0, [element]);
+
+      proxyA.fragment = fragment;
+      await waitMicrotask();
+
+      bootstrapA({});
+      await waitMicrotask();
+
+      // B should see the fragment
+      expect(proxyB.fragment).toBeInstanceOf(Y.XmlFragment);
+      expect(proxyB.fragment).toHaveLength(1);
+      expect(proxyB.fragment.get(0)).toBeInstanceOf(Y.XmlElement);
+    });
+
+    it("syncs insertions into Y.XmlFragment", async () => {
+      const { proxyA, proxyB, bootstrapA } = createRelayedProxiesMapRoot();
+
+      const fragment = new Y.XmlFragment();
+      proxyA.fragment = fragment;
+      await waitMicrotask();
+
+      bootstrapA({});
+      await waitMicrotask();
+
+      // A inserts an element
+      const element = new Y.XmlElement("p");
+      proxyA.fragment.insert(0, [element]);
+      await waitMicrotask();
+
+      // B sees the insertion
+      expect(proxyB.fragment).toHaveLength(1);
+      expect(proxyB.fragment.get(0)).toBeInstanceOf(Y.XmlElement);
+      expect(proxyB.fragment.get(0).nodeName).toBe("p");
+    });
+
+    it("syncs deletions from Y.XmlFragment", async () => {
+      const { proxyA, proxyB, bootstrapA } = createRelayedProxiesMapRoot();
+
+      const fragment = new Y.XmlFragment();
+      const el1 = new Y.XmlElement("div");
+      const el2 = new Y.XmlElement("span");
+      const el3 = new Y.XmlElement("p");
+      fragment.insert(0, [el1, el2, el3]);
+
+      proxyA.fragment = fragment;
+      await waitMicrotask();
+
+      bootstrapA({});
+      await waitMicrotask();
+
+      expect(proxyB.fragment).toHaveLength(3);
+
+      // A deletes the middle element
+      proxyA.fragment.delete(1, 1);
+      await waitMicrotask();
+
+      // B sees the deletion
+      expect(proxyB.fragment).toHaveLength(2);
+      expect(proxyB.fragment.get(0).nodeName).toBe("div");
+      expect(proxyB.fragment.get(1).nodeName).toBe("p");
+    });
+
+    it("handles empty Y.XmlFragment", async () => {
+      const { proxyA, proxyB, bootstrapA } = createRelayedProxiesMapRoot();
+
+      const fragment = new Y.XmlFragment();
+      proxyA.fragment = fragment;
+      await waitMicrotask();
+
+      bootstrapA({});
+      await waitMicrotask();
+
+      // B should see empty fragment
+      expect(proxyB.fragment).toBeInstanceOf(Y.XmlFragment);
+      expect(proxyB.fragment).toHaveLength(0);
+    });
+  });
+
+  describe("Y.XmlElement", () => {
+    it("can create and sync Y.XmlElement with attributes", async () => {
+      const { proxyA, proxyB, bootstrapA } = createRelayedProxiesMapRoot();
+
+      // Create XmlElement with attributes
+      const element = new Y.XmlElement("div");
+      element.setAttribute("class", "container");
+      element.setAttribute("id", "main");
+
+      proxyA.element = element;
+      await waitMicrotask();
+
+      bootstrapA({});
+      await waitMicrotask();
+
+      // B should see the element with attributes
+      expect(proxyB.element).toBeInstanceOf(Y.XmlElement);
+      expect(proxyB.element.nodeName).toBe("div");
+      expect(proxyB.element.getAttribute("class")).toBe("container");
+      expect(proxyB.element.getAttribute("id")).toBe("main");
+    });
+
+    it("syncs attribute changes", async () => {
+      const { proxyA, proxyB, bootstrapA } = createRelayedProxiesMapRoot();
+
+      const element = new Y.XmlElement("div");
+      proxyA.element = element;
+      await waitMicrotask();
+
+      bootstrapA({});
+      await waitMicrotask();
+
+      // A sets attribute
+      proxyA.element.setAttribute("data-test", "value");
+      await waitMicrotask();
+
+      // B sees the attribute
+      expect(proxyB.element.getAttribute("data-test")).toBe("value");
+    });
+
+    it("syncs children insertions", async () => {
+      const { proxyA, proxyB, bootstrapA } = createRelayedProxiesMapRoot();
+
+      const element = new Y.XmlElement("div");
+      proxyA.element = element;
+      await waitMicrotask();
+
+      bootstrapA({});
+      await waitMicrotask();
+
+      // A inserts a child
+      const child = new Y.XmlElement("span");
+      proxyA.element.insert(0, [child]);
+      await waitMicrotask();
+
+      // B sees the child
+      expect(proxyB.element).toHaveLength(1);
+      expect(proxyB.element.get(0)).toBeInstanceOf(Y.XmlElement);
+      expect(proxyB.element.get(0).nodeName).toBe("span");
+    });
+
+    it("syncs Y.XmlText children", async () => {
+      const { proxyA, proxyB, bootstrapA } = createRelayedProxiesMapRoot();
+
+      const element = new Y.XmlElement("p");
+      const text = new Y.XmlText("Hello World");
+      element.insert(0, [text]);
+
+      proxyA.element = element;
+      await waitMicrotask();
+
+      bootstrapA({});
+      await waitMicrotask();
+
+      // B sees the text
+      expect(proxyB.element).toHaveLength(1);
+      expect(proxyB.element.get(0)).toBeInstanceOf(Y.XmlText);
+      expect(proxyB.element.get(0).toString()).toBe("Hello World");
+
+      // A edits the text
+      proxyA.element.get(0).insert(11, "!");
+      await waitMicrotask();
+
+      // B sees the edit
+      expect(proxyB.element.get(0).toString()).toBe("Hello World!");
+    });
+
+    it("syncs attribute deletions", async () => {
+      const { proxyA, proxyB, bootstrapA } = createRelayedProxiesMapRoot();
+
+      const element = new Y.XmlElement("div");
+      element.setAttribute("class", "test");
+      element.setAttribute("id", "main");
+
+      proxyA.element = element;
+      await waitMicrotask();
+
+      bootstrapA({});
+      await waitMicrotask();
+
+      expect(proxyB.element.getAttribute("class")).toBe("test");
+      expect(proxyB.element.getAttribute("id")).toBe("main");
+
+      // A removes an attribute
+      proxyA.element.removeAttribute("class");
+      await waitMicrotask();
+
+      // B sees the removal
+      expect(proxyB.element.getAttribute("class")).toBeUndefined();
+      expect(proxyB.element.getAttribute("id")).toBe("main");
+    });
+
+    it("syncs child removals from Y.XmlElement", async () => {
+      const { proxyA, proxyB, bootstrapA } = createRelayedProxiesMapRoot();
+
+      const element = new Y.XmlElement("div");
+      const child1 = new Y.XmlElement("span");
+      const child2 = new Y.XmlElement("p");
+      element.insert(0, [child1, child2]);
+
+      proxyA.element = element;
+      await waitMicrotask();
+
+      bootstrapA({});
+      await waitMicrotask();
+
+      expect(proxyB.element).toHaveLength(2);
+
+      // A removes first child
+      proxyA.element.delete(0, 1);
+      await waitMicrotask();
+
+      // B sees the removal
+      expect(proxyB.element).toHaveLength(1);
+      expect(proxyB.element.get(0).nodeName).toBe("p");
+    });
+
+    it("handles empty Y.XmlElement", async () => {
+      const { proxyA, proxyB, bootstrapA } = createRelayedProxiesMapRoot();
+
+      const element = new Y.XmlElement("div");
+      // No attributes, no children
+
+      proxyA.element = element;
+      await waitMicrotask();
+
+      bootstrapA({});
+      await waitMicrotask();
+
+      // B should see empty element
+      expect(proxyB.element).toBeInstanceOf(Y.XmlElement);
+      expect(proxyB.element.nodeName).toBe("div");
+      expect(proxyB.element).toHaveLength(0);
+    });
+
+    it("handles deeply nested Y.XmlElement structures", async () => {
+      const { proxyA, proxyB, bootstrapA } = createRelayedProxiesMapRoot();
+
+      // Create 5-level deep structure
+      const level1 = new Y.XmlElement("div");
+      const level2 = new Y.XmlElement("section");
+      const level3 = new Y.XmlElement("article");
+      const level4 = new Y.XmlElement("p");
+      const level5 = new Y.XmlText("Deep content");
+
+      level4.insert(0, [level5]);
+      level3.insert(0, [level4]);
+      level2.insert(0, [level3]);
+      level1.insert(0, [level2]);
+
+      proxyA.root = level1;
+      await waitMicrotask();
+
+      bootstrapA({});
+      await waitMicrotask();
+
+      // B sees the full depth
+      expect(proxyB.root.nodeName).toBe("div");
+      expect(proxyB.root.get(0).nodeName).toBe("section");
+      expect(proxyB.root.get(0).get(0).nodeName).toBe("article");
+      expect(proxyB.root.get(0).get(0).get(0).nodeName).toBe("p");
+      expect(proxyB.root.get(0).get(0).get(0).get(0).toString()).toBe(
+        "Deep content",
+      );
+    });
+  });
+
+  describe("Y.XmlHook", () => {
+    it("can create and sync Y.XmlHook as a map-like container", async () => {
+      const { proxyA, proxyB, bootstrapA } = createRelayedProxiesMapRoot();
+
+      // Create XmlHook (behaves like Y.Map)
+      const hook = new Y.XmlHook("custom-hook");
+      hook.set("data", "value");
+      hook.set("count", 42);
+
+      proxyA.hook = hook;
+      await waitMicrotask();
+
+      bootstrapA({});
+      await waitMicrotask();
+
+      // B should see the hook
+      expect(proxyB.hook).toBeInstanceOf(Y.XmlHook);
+      expect(proxyB.hook.get("data")).toBe("value");
+      expect(proxyB.hook.get("count")).toBe(42);
+    });
+
+    it("syncs Y.XmlHook property changes", async () => {
+      const { proxyA, proxyB, bootstrapA } = createRelayedProxiesMapRoot();
+
+      const hook = new Y.XmlHook("custom-hook");
+      proxyA.hook = hook;
+      await waitMicrotask();
+
+      bootstrapA({});
+      await waitMicrotask();
+
+      // A sets a property
+      proxyA.hook.set("status", "active");
+      await waitMicrotask();
+
+      // B sees the property
+      expect(proxyB.hook.get("status")).toBe("active");
+    });
+
+    it("triggers Valtio updates when Y.XmlHook content changes", async () => {
+      const { proxyA, proxyB, bootstrapA } = createRelayedProxiesMapRoot();
+
+      const hook = new Y.XmlHook("test");
+      proxyA.hook = hook;
+      await waitMicrotask();
+
+      bootstrapA({});
+      await waitMicrotask();
+
+      let renderCount = 0;
+      // Subscribe to changes on B's proxy
+      const unsub = subscribe(proxyB, () => {
+        renderCount++;
+      });
+
+      // Change via A
+      proxyA.hook.set("key", "value");
+      await waitMicrotask();
+
+      // Verify reactivity triggered
+      expect(renderCount).toBeGreaterThan(0);
+      expect(proxyB.hook.get("key")).toBe("value");
+
+      unsub();
+    });
+
+    it("syncs Y.XmlHook property deletions", async () => {
+      const { proxyA, proxyB, bootstrapA } = createRelayedProxiesMapRoot();
+
+      const hook = new Y.XmlHook("test");
+      hook.set("key1", "value1");
+      hook.set("key2", "value2");
+
+      proxyA.hook = hook;
+      await waitMicrotask();
+
+      bootstrapA({});
+      await waitMicrotask();
+
+      expect(proxyB.hook.get("key1")).toBe("value1");
+      expect(proxyB.hook.get("key2")).toBe("value2");
+
+      // A deletes a property
+      proxyA.hook.delete("key1");
+      await waitMicrotask();
+
+      // B sees the deletion
+      expect(proxyB.hook.has("key1")).toBe(false);
+      expect(proxyB.hook.get("key2")).toBe("value2");
+    });
+  });
+
+  describe("Mixed XML Structures", () => {
+    it("handles nested XML elements with mixed content", async () => {
+      const { proxyA, proxyB, bootstrapA } = createRelayedProxiesMapRoot();
+
+      // Create a complex XML structure
+      const root = new Y.XmlElement("article");
+      root.setAttribute("lang", "en");
+
+      const title = new Y.XmlElement("h1");
+      const titleText = new Y.XmlText("My Article");
+      title.insert(0, [titleText]);
+
+      const paragraph = new Y.XmlElement("p");
+      const paraText = new Y.XmlText("Some content");
+      paragraph.insert(0, [paraText]);
+
+      root.insert(0, [title, paragraph]);
+
+      proxyA.article = root;
+      await waitMicrotask();
+
+      bootstrapA({});
+      await waitMicrotask();
+
+      // B sees the full structure
+      expect(proxyB.article).toBeInstanceOf(Y.XmlElement);
+      expect(proxyB.article.nodeName).toBe("article");
+      expect(proxyB.article.getAttribute("lang")).toBe("en");
+      expect(proxyB.article).toHaveLength(2);
+
+      const h1 = proxyB.article.get(0);
+      expect(h1.nodeName).toBe("h1");
+      expect(h1.get(0).toString()).toBe("My Article");
+
+      const p = proxyB.article.get(1);
+      expect(p.nodeName).toBe("p");
+      expect(p.get(0).toString()).toBe("Some content");
+    });
+
+    it("handles XML types mixed with regular objects", async () => {
+      const { proxyA, proxyB, bootstrapA } = createRelayedProxiesMapRoot();
+
+      const element = new Y.XmlElement("article");
+      element.setAttribute("id", "main");
+
+      proxyA.data = {
+        title: "Regular string",
+        content: element,
+        metadata: { count: 0 },
+      };
+      await waitMicrotask();
+
+      bootstrapA({});
+      await waitMicrotask();
+
+      // B sees mixed structure
+      expect(proxyB.data.title).toBe("Regular string");
+      expect(proxyB.data.content).toBeInstanceOf(Y.XmlElement);
+      expect(proxyB.data.content.nodeName).toBe("article");
+      expect(proxyB.data.content.getAttribute("id")).toBe("main");
+      expect(proxyB.data.metadata.count).toBe(0);
+    });
+  });
+
+  describe("XML Types in Arrays", () => {
+    it("can store Y.XmlElement in Y.Array", async () => {
+      const { proxyA, proxyB, bootstrapA } = createRelayedProxiesArrayRoot();
+
+      const el1 = new Y.XmlElement("div");
+      el1.setAttribute("class", "item1");
+      const el2 = new Y.XmlElement("span");
+      el2.setAttribute("class", "item2");
+
+      proxyA.push(el1, el2);
+      await waitMicrotask();
+
+      bootstrapA([]);
+      await waitMicrotask();
+
+      // B sees the XML elements in array
+      expect(proxyB).toHaveLength(2);
+      expect(proxyB[0]).toBeInstanceOf(Y.XmlElement);
+      expect(proxyB[0].nodeName).toBe("div");
+      expect(proxyB[0].getAttribute("class")).toBe("item1");
+      expect(proxyB[1]).toBeInstanceOf(Y.XmlElement);
+      expect(proxyB[1].nodeName).toBe("span");
+      expect(proxyB[1].getAttribute("class")).toBe("item2");
+    });
+
+    it("syncs XML element changes in array", async () => {
+      const { proxyA, proxyB, bootstrapA } = createRelayedProxiesArrayRoot();
+
+      const element = new Y.XmlElement("p");
+      proxyA.push(element);
+      await waitMicrotask();
+
+      bootstrapA([]);
+      await waitMicrotask();
+
+      // A modifies the element
+      proxyA[0].setAttribute("data-test", "value");
+      await waitMicrotask();
+
+      // B sees the change
+      expect(proxyB[0].getAttribute("data-test")).toBe("value");
+    });
+
+    it("can store Y.XmlHook in Y.Array", async () => {
+      const { proxyA, proxyB, bootstrapA } = createRelayedProxiesArrayRoot();
+
+      const hook1 = new Y.XmlHook("hook1");
+      hook1.set("name", "first");
+      const hook2 = new Y.XmlHook("hook2");
+      hook2.set("name", "second");
+
+      proxyA.push(hook1, hook2);
+      await waitMicrotask();
+
+      bootstrapA([]);
+      await waitMicrotask();
+
+      // B sees the hooks in array
+      expect(proxyB).toHaveLength(2);
+      expect(proxyB[0]).toBeInstanceOf(Y.XmlHook);
+      expect(proxyB[0].get("name")).toBe("first");
+      expect(proxyB[1]).toBeInstanceOf(Y.XmlHook);
+      expect(proxyB[1].get("name")).toBe("second");
+    });
+
+    it("can store Y.XmlFragment in Y.Array", async () => {
+      const { proxyA, proxyB, bootstrapA } = createRelayedProxiesArrayRoot();
+
+      const fragment = new Y.XmlFragment();
+      const element = new Y.XmlElement("div");
+      fragment.insert(0, [element]);
+
+      proxyA.push(fragment);
+      await waitMicrotask();
+
+      bootstrapA([]);
+      await waitMicrotask();
+
+      // B sees the fragment in array
+      expect(proxyB).toHaveLength(1);
+      expect(proxyB[0]).toBeInstanceOf(Y.XmlFragment);
+      expect(proxyB[0]).toHaveLength(1);
+      expect(proxyB[0].get(0).nodeName).toBe("div");
+    });
+  });
+});

--- a/valtio-y/tests/e2e/e2e.ytext-collaboration.spec.ts
+++ b/valtio-y/tests/e2e/e2e.ytext-collaboration.spec.ts
@@ -1,0 +1,701 @@
+/* eslint @typescript-eslint/no-explicit-any: "off" */
+
+import { describe, it, expect } from "vitest";
+import * as Y from "yjs";
+import { syncedText } from "../../src/index";
+import {
+  createRelayedProxiesMapRoot,
+  waitMicrotask,
+} from "../helpers/test-helpers";
+
+describe("E2E: Y.Text Collaboration", () => {
+  describe("Two Clients: Basic Y.Text Collaboration", () => {
+    it("two clients can edit the same Y.Text document", async () => {
+      const { proxyA, proxyB } = createRelayedProxiesMapRoot();
+
+      // Client A creates a document with Y.Text
+      const text = syncedText("Hello World");
+      proxyA.document = text;
+      await waitMicrotask();
+
+      // Both clients should see the same text
+      expect(proxyB.document).toBeInstanceOf(Y.Text);
+      expect(proxyB.document.toString()).toBe("Hello World");
+
+      // Client B edits
+      proxyB.document.insert(11, "!");
+      await waitMicrotask();
+
+      // Client A sees the change
+      expect(proxyA.document.toString()).toBe("Hello World!");
+    });
+
+    it("multiple Y.Text instances can be edited independently", async () => {
+      const { proxyA, proxyB } = createRelayedProxiesMapRoot();
+
+      const title = syncedText("Title");
+      const body = syncedText("Body content");
+      proxyA.title = title;
+      proxyA.body = body;
+      await waitMicrotask();
+
+      // Edit title on A
+      proxyA.title.insert(5, " Text");
+      await waitMicrotask();
+
+      // Edit body on B
+      proxyB.body.insert(12, " here");
+      await waitMicrotask();
+
+      // Both clients see both changes
+      expect(proxyA.title.toString()).toBe("Title Text");
+      expect(proxyA.body.toString()).toBe("Body content here");
+      expect(proxyB.title.toString()).toBe("Title Text");
+      expect(proxyB.body.toString()).toBe("Body content here");
+    });
+  });
+
+  describe("Concurrent Text Inserts", () => {
+    it("concurrent inserts at different positions merge correctly", async () => {
+      const { proxyA, proxyB } = createRelayedProxiesMapRoot();
+
+      const text = syncedText("Hello World");
+      proxyA.text = text;
+      await waitMicrotask();
+
+      // Sequential inserts with sync to ensure proper positions
+      proxyA.text.insert(0, "Start: ");
+      await waitMicrotask();
+
+      // Now B can safely insert at the end
+      proxyB.text.insert(proxyB.text.length, " End");
+      await waitMicrotask();
+
+      // Both should converge to the same state
+      const contentA = proxyA.text.toString();
+      const contentB = proxyB.text.toString();
+
+      expect(contentA).toBe(contentB);
+      expect(contentA).toContain("Start:");
+      expect(contentA).toContain("Hello");
+      expect(contentA).toContain("World");
+      expect(contentA).toContain("End");
+      expect(contentA).toBe("Start: Hello World End");
+    });
+
+    it("concurrent inserts at same position are ordered deterministically", async () => {
+      const { proxyA, proxyB } = createRelayedProxiesMapRoot();
+
+      const text = syncedText("");
+      proxyA.text = text;
+      await waitMicrotask();
+
+      // Both clients insert at position 0
+      proxyA.text.insert(0, "A");
+      proxyB.text.insert(0, "B");
+      await waitMicrotask();
+
+      // CRDT ensures deterministic ordering
+      const contentA = proxyA.text.toString();
+      const contentB = proxyB.text.toString();
+
+      expect(contentA).toBe(contentB);
+      expect(contentA).toHaveLength(2);
+      // Y.js CRDT will order these deterministically
+      expect(["AB", "BA"]).toContain(contentA);
+    });
+
+    it("rapid concurrent inserts converge correctly", async () => {
+      const { proxyA, proxyB } = createRelayedProxiesMapRoot();
+
+      const text = syncedText("");
+      proxyA.text = text;
+      await waitMicrotask();
+
+      // Rapid inserts from both clients
+      proxyA.text.insert(0, "A1");
+      proxyA.text.insert(2, "A2");
+      proxyB.text.insert(0, "B1");
+      proxyB.text.insert(2, "B2");
+      await waitMicrotask();
+
+      // Should converge to same state
+      const contentA = proxyA.text.toString();
+      const contentB = proxyB.text.toString();
+
+      expect(contentA).toBe(contentB);
+      expect(contentA).toContain("A1");
+      expect(contentA).toContain("A2");
+      expect(contentA).toContain("B1");
+      expect(contentA).toContain("B2");
+    });
+
+    it("interleaved character inserts maintain consistency", async () => {
+      const { proxyA, proxyB } = createRelayedProxiesMapRoot();
+
+      const text = syncedText("abcdef");
+      proxyA.text = text;
+      await waitMicrotask();
+
+      // A inserts at position 2
+      proxyA.text.insert(2, "X");
+      await waitMicrotask();
+
+      // B inserts at position 1 (after A's sync)
+      proxyB.text.insert(1, "1");
+      await waitMicrotask();
+
+      // A inserts at updated position
+      const posA = proxyA.text.toString().indexOf("X") + 2;
+      proxyA.text.insert(posA, "Y");
+      await waitMicrotask();
+
+      // B inserts near end
+      proxyB.text.insert(proxyB.text.length - 1, "2");
+      await waitMicrotask();
+      // Extra wait to ensure all updates propagate through relay
+      await waitMicrotask();
+
+      const contentA = proxyA.text.toString();
+      const contentB = proxyB.text.toString();
+
+      expect(contentA).toBe(contentB);
+      expect(contentA).toHaveLength(10); // Original 6 + 4 inserts
+      expect(contentA).toContain("X");
+      expect(contentA).toContain("Y");
+      expect(contentA).toContain("1");
+      expect(contentA).toContain("2");
+    });
+  });
+
+  describe("Concurrent Text Deletes", () => {
+    it("concurrent deletes at different positions merge correctly", async () => {
+      const { proxyA, proxyB } = createRelayedProxiesMapRoot();
+
+      const text = syncedText("Hello Beautiful World");
+      proxyA.text = text;
+      await waitMicrotask();
+
+      // A deletes "Beautiful " (positions 6-16)
+      proxyA.text.delete(6, 10);
+
+      // B deletes "Hello " (positions 0-6)
+      proxyB.text.delete(0, 6);
+
+      await waitMicrotask();
+
+      const contentA = proxyA.text.toString();
+      const contentB = proxyB.text.toString();
+
+      expect(contentA).toBe(contentB);
+      // After both deletions, only "World" should remain
+      expect(contentA).toBe("World");
+    });
+
+    it("overlapping deletes handle conflicts gracefully", async () => {
+      const { proxyA, proxyB } = createRelayedProxiesMapRoot();
+
+      const text = syncedText("0123456789");
+      proxyA.text = text;
+      await waitMicrotask();
+
+      // A deletes positions 2-5 ("234")
+      proxyA.text.delete(2, 3);
+
+      // B deletes positions 4-7 ("456")
+      proxyB.text.delete(4, 3);
+
+      await waitMicrotask();
+
+      const contentA = proxyA.text.toString();
+      const contentB = proxyB.text.toString();
+
+      expect(contentA).toBe(contentB);
+      // CRDT ensures consistent state despite overlap
+      expect(contentA.length).toBeLessThan(10);
+    });
+
+    it("delete entire content from one client while other inserts", async () => {
+      const { proxyA, proxyB } = createRelayedProxiesMapRoot();
+
+      const text = syncedText("Hello World");
+      proxyA.text = text;
+      await waitMicrotask();
+
+      // A deletes everything
+      proxyA.text.delete(0, 11);
+
+      // B inserts at the end (concurrent with delete)
+      proxyB.text.insert(11, "!");
+
+      await waitMicrotask();
+
+      const contentA = proxyA.text.toString();
+      const contentB = proxyB.text.toString();
+
+      expect(contentA).toBe(contentB);
+      // Y.js CRDT will preserve the insert despite the delete
+      // The exclamation mark should survive
+      expect(contentA).toContain("!");
+    });
+  });
+
+  describe("Mixed Insert and Delete Operations", () => {
+    it("concurrent insert and delete at same position", async () => {
+      const { proxyA, proxyB } = createRelayedProxiesMapRoot();
+
+      const text = syncedText("Hello World");
+      proxyA.text = text;
+      await waitMicrotask();
+
+      // A inserts at position 5
+      proxyA.text.insert(5, "XXX");
+
+      // B deletes at position 5 (the space character)
+      proxyB.text.delete(5, 1);
+
+      await waitMicrotask();
+
+      const contentA = proxyA.text.toString();
+      const contentB = proxyB.text.toString();
+
+      expect(contentA).toBe(contentB);
+      // CRDT ensures deterministic resolution - delete happens on original position
+      // The insert and delete are concurrent, so both should apply
+      expect(contentA.length).toBeLessThan(14); // Original + XXX - 1 deleted char
+    });
+
+    it("replace operation (delete + insert) conflicts with concurrent insert", async () => {
+      const { proxyA, proxyB } = createRelayedProxiesMapRoot();
+
+      const text = syncedText("Hello World");
+      proxyA.text = text;
+      await waitMicrotask();
+
+      // A replaces "World" with "Universe"
+      proxyA.text.delete(6, 5);
+      proxyA.text.insert(6, "Universe");
+
+      // B inserts in the middle of "World"
+      proxyB.text.insert(8, "XXX");
+
+      await waitMicrotask();
+
+      const contentA = proxyA.text.toString();
+      const contentB = proxyB.text.toString();
+
+      expect(contentA).toBe(contentB);
+      expect(contentA).toContain("Hello");
+    });
+
+    it("multiple clients performing complex edits simultaneously", async () => {
+      const { proxyA, proxyB } = createRelayedProxiesMapRoot();
+
+      const text = syncedText("The quick brown fox jumps over the lazy dog");
+      proxyA.text = text;
+      await waitMicrotask();
+
+      // A: Replace "quick" with "slow"
+      proxyA.text.delete(4, 5);
+      proxyA.text.insert(4, "slow");
+      await waitMicrotask();
+
+      // B: Insert "very " before "lazy" (after sync)
+      const lazyIndex = proxyB.text.toString().indexOf("lazy");
+      proxyB.text.insert(lazyIndex, "very ");
+      await waitMicrotask();
+
+      // A: Delete "fox "
+      const foxIndex = proxyA.text.toString().indexOf("fox ");
+      proxyA.text.delete(foxIndex, 4);
+      await waitMicrotask();
+
+      // B: Replace "dog" with "cat" (after A's deletion syncs)
+      await waitMicrotask(); // Extra sync to ensure A's changes are visible
+      const dogIndex = proxyB.text.toString().indexOf("dog");
+      proxyB.text.delete(dogIndex, 3);
+      proxyB.text.insert(dogIndex, "cat");
+      await waitMicrotask();
+      // Extra wait for full convergence
+      await waitMicrotask();
+
+      const contentA = proxyA.text.toString();
+      const contentB = proxyB.text.toString();
+
+      // Both should converge
+      expect(contentA).toBe(contentB);
+      expect(contentA).toBe("The slow brown jumps over the very lazy cat");
+    });
+  });
+
+  describe("Y.Text Formatting (Attributes)", () => {
+    it("can apply and sync text formatting attributes", async () => {
+      const { proxyA, proxyB } = createRelayedProxiesMapRoot();
+
+      const text = syncedText("Hello World");
+      proxyA.text = text;
+      await waitMicrotask();
+
+      // A applies bold formatting to "Hello"
+      proxyA.text.format(0, 5, { bold: true });
+      await waitMicrotask();
+
+      // B should see the formatting (accessed via toDelta or similar)
+      const deltaA = proxyA.text.toDelta();
+      const deltaB = proxyB.text.toDelta();
+
+      expect(deltaA).toEqual(deltaB);
+      expect(deltaA[0]).toHaveProperty("attributes");
+      expect(deltaA[0].attributes).toEqual({ bold: true });
+    });
+
+    it("concurrent formatting operations on different ranges", async () => {
+      const { proxyA, proxyB } = createRelayedProxiesMapRoot();
+
+      const text = syncedText("Hello Beautiful World");
+      proxyA.text = text;
+      await waitMicrotask();
+
+      // A formats "Hello" as bold
+      proxyA.text.format(0, 5, { bold: true });
+
+      // B formats "World" as italic
+      proxyB.text.format(16, 5, { italic: true });
+
+      await waitMicrotask();
+
+      const deltaA = proxyA.text.toDelta();
+      const deltaB = proxyB.text.toDelta();
+
+      expect(deltaA).toEqual(deltaB);
+
+      // Find the formatted segments
+      const boldSegment = deltaA.find((d: any) => d.attributes?.bold);
+      const italicSegment = deltaA.find((d: any) => d.attributes?.italic);
+
+      expect(boldSegment).toBeDefined();
+      expect(italicSegment).toBeDefined();
+    });
+
+    it("concurrent formatting on overlapping ranges", async () => {
+      const { proxyA, proxyB } = createRelayedProxiesMapRoot();
+
+      const text = syncedText("Hello World");
+      proxyA.text = text;
+      await waitMicrotask();
+
+      // A formats positions 0-7 as bold
+      proxyA.text.format(0, 7, { bold: true });
+
+      // B formats positions 6-11 as italic
+      proxyB.text.format(6, 5, { italic: true });
+
+      await waitMicrotask();
+
+      const deltaA = proxyA.text.toDelta();
+      const deltaB = proxyB.text.toDelta();
+
+      expect(deltaA).toEqual(deltaB);
+
+      // Overlapping region should have both attributes
+      const overlapping = deltaA.find(
+        (d: any) => d.attributes?.bold && d.attributes?.italic,
+      );
+      expect(overlapping).toBeDefined();
+    });
+
+    it("formatting persists through concurrent text edits", async () => {
+      const { proxyA, proxyB } = createRelayedProxiesMapRoot();
+
+      const text = syncedText("Hello World");
+      proxyA.text = text;
+      await waitMicrotask();
+
+      // A applies formatting
+      proxyA.text.format(0, 5, { bold: true });
+      await waitMicrotask();
+
+      // B inserts text in the middle
+      proxyB.text.insert(5, " Beautiful");
+      await waitMicrotask();
+
+      const deltaA = proxyA.text.toDelta();
+      const deltaB = proxyB.text.toDelta();
+
+      expect(deltaA).toEqual(deltaB);
+      expect(proxyA.text.toString()).toBe("Hello Beautiful World");
+
+      // Original formatting should still exist
+      const boldSegment = deltaA.find((d: any) => d.attributes?.bold);
+      expect(boldSegment).toBeDefined();
+    });
+
+    it("removing formatting syncs correctly", async () => {
+      const { proxyA, proxyB } = createRelayedProxiesMapRoot();
+
+      const text = syncedText("Hello World");
+      proxyA.text = text;
+      await waitMicrotask();
+
+      // A applies formatting
+      proxyA.text.format(0, 11, { bold: true });
+      await waitMicrotask();
+
+      // Verify B sees it
+      expect(proxyB.text.toDelta()[0].attributes).toEqual({ bold: true });
+
+      // A removes formatting
+      proxyA.text.format(0, 11, { bold: null });
+      await waitMicrotask();
+
+      const deltaA = proxyA.text.toDelta();
+      const deltaB = proxyB.text.toDelta();
+
+      expect(deltaA).toEqual(deltaB);
+      // No attributes should remain
+      expect(deltaA.every((d: any) => !d.attributes?.bold)).toBe(true);
+    });
+  });
+
+  describe("Y.Text in Complex Structures", () => {
+    it("multiple Y.Text instances in array sync correctly", async () => {
+      const { proxyA, proxyB } = createRelayedProxiesMapRoot();
+
+      const text1 = syncedText("First");
+      const text2 = syncedText("Second");
+      proxyA.texts = [text1, text2];
+      await waitMicrotask();
+
+      // Edit both texts from different clients
+      proxyA.texts[0].insert(5, " Text");
+      proxyB.texts[1].insert(6, " Text");
+      await waitMicrotask();
+
+      expect(proxyA.texts[0].toString()).toBe("First Text");
+      expect(proxyA.texts[1].toString()).toBe("Second Text");
+      expect(proxyB.texts[0].toString()).toBe("First Text");
+      expect(proxyB.texts[1].toString()).toBe("Second Text");
+    });
+
+    it("Y.Text in nested objects sync correctly", async () => {
+      const { proxyA, proxyB } = createRelayedProxiesMapRoot();
+
+      proxyA.document = {
+        title: syncedText("Document Title"),
+        sections: [
+          {
+            heading: syncedText("Section 1"),
+            content: syncedText("Content here"),
+          },
+        ],
+      };
+      await waitMicrotask();
+
+      // Edit from both clients
+      proxyA.document.title.insert(0, "My ");
+      proxyB.document.sections[0].content.insert(12, " and there");
+      await waitMicrotask();
+
+      expect(proxyA.document.title.toString()).toBe("My Document Title");
+      expect(proxyB.document.title.toString()).toBe("My Document Title");
+      expect(proxyA.document.sections[0].content.toString()).toBe(
+        "Content here and there",
+      );
+      expect(proxyB.document.sections[0].content.toString()).toBe(
+        "Content here and there",
+      );
+    });
+
+    it("replacing Y.Text while other client edits it", async () => {
+      const { proxyA, proxyB } = createRelayedProxiesMapRoot();
+
+      const text = syncedText("Original");
+      proxyA.text = text;
+      await waitMicrotask();
+
+      // A replaces the entire text with a new Y.Text (this is a map key change)
+      const newText = syncedText("Replaced");
+      proxyA.text = newText;
+      await waitMicrotask();
+
+      // B edits after the replacement syncs
+      proxyB.text.insert(8, " Content");
+      await waitMicrotask();
+
+      // Both should see the new text with B's edit
+      expect(proxyA.text.toString()).toBe("Replaced Content");
+      expect(proxyB.text.toString()).toBe("Replaced Content");
+    });
+  });
+
+  describe("Large Scale Y.Text Operations", () => {
+    it("handles large text documents efficiently", async () => {
+      const { proxyA, proxyB } = createRelayedProxiesMapRoot();
+
+      // Create a large document
+      const largeText = "Lorem ipsum dolor sit amet. ".repeat(100);
+      const text = syncedText(largeText);
+      proxyA.text = text;
+      await waitMicrotask();
+
+      expect(proxyB.text.toString()).toBe(largeText);
+      expect(proxyB.text.toString().length).toBeGreaterThan(2000);
+
+      // Edit from both clients
+      proxyA.text.insert(0, "START: ");
+      proxyB.text.insert(proxyB.text.length, " :END");
+      await waitMicrotask();
+
+      const contentA = proxyA.text.toString();
+      const contentB = proxyB.text.toString();
+
+      expect(contentA).toBe(contentB);
+      expect(contentA).toContain("START:");
+      expect(contentA).toContain(":END");
+    });
+
+    it("handles many small edits in sequence", async () => {
+      const { proxyA, proxyB } = createRelayedProxiesMapRoot();
+
+      const text = syncedText("");
+      proxyA.text = text;
+      await waitMicrotask();
+
+      // Simulate typing from both clients with sync after each operation
+      for (let i = 0; i < 5; i++) {
+        // A appends
+        proxyA.text.insert(proxyA.text.length, "A");
+        await waitMicrotask();
+        // B inserts at beginning
+        proxyB.text.insert(0, "B");
+        await waitMicrotask();
+      }
+
+      // Extra waits for full convergence
+      await waitMicrotask();
+      await waitMicrotask();
+
+      const contentA = proxyA.text.toString();
+      const contentB = proxyB.text.toString();
+
+      // Both should converge
+      expect(contentA).toBe(contentB);
+      expect(contentA).toHaveLength(10);
+      // Count occurrences - should have 5 A's and 5 B's
+      const aCount = (contentA.match(/A/g) || []).length;
+      const bCount = (contentA.match(/B/g) || []).length;
+      expect(aCount).toBe(5);
+      expect(bCount).toBe(5);
+    });
+  });
+
+  describe("Y.Text Identity and References", () => {
+    it("Y.Text works correctly and syncs across edits", async () => {
+      const { proxyA, proxyB } = createRelayedProxiesMapRoot();
+
+      const text = syncedText("Hello");
+      proxyA.text = text;
+      await waitMicrotask();
+
+      const refA = proxyA.text;
+      const refB = proxyB.text;
+
+      // Edit from both clients
+      proxyA.text.insert(5, " World");
+      proxyB.text.insert(0, "Say: ");
+      await waitMicrotask();
+
+      // Y.Text should work correctly after modifications
+      // Note: References may be different proxy wrappers, but content should be correct
+      expect(proxyA.text).toBeInstanceOf(Y.Text);
+      expect(proxyB.text).toBeInstanceOf(Y.Text);
+      expect(refA.toString()).toBe("Say: Hello World");
+      expect(refB.toString()).toBe("Say: Hello World");
+      expect(proxyA.text.toString()).toBe("Say: Hello World");
+      expect(proxyB.text.toString()).toBe("Say: Hello World");
+    });
+
+    it("different Y.Text instances maintain separate identities", async () => {
+      const { proxyA, proxyB } = createRelayedProxiesMapRoot();
+
+      const text1 = syncedText("Text 1");
+      const text2 = syncedText("Text 2");
+      proxyA.text1 = text1;
+      proxyA.text2 = text2;
+      await waitMicrotask();
+
+      expect(proxyA.text1).not.toBe(proxyA.text2);
+      expect(proxyB.text1).not.toBe(proxyB.text2);
+
+      // Edits don't cross-contaminate
+      proxyA.text1.insert(6, " A");
+      proxyB.text2.insert(6, " B");
+      await waitMicrotask();
+
+      expect(proxyA.text1.toString()).toBe("Text 1 A");
+      expect(proxyA.text2.toString()).toBe("Text 2 B");
+      expect(proxyB.text1.toString()).toBe("Text 1 A");
+      expect(proxyB.text2.toString()).toBe("Text 2 B");
+    });
+  });
+
+  describe("Edge Cases and Error Scenarios", () => {
+    it("handles empty Y.Text collaboration", async () => {
+      const { proxyA, proxyB } = createRelayedProxiesMapRoot();
+
+      const text = syncedText();
+      proxyA.text = text;
+      await waitMicrotask();
+
+      expect(proxyB.text.toString()).toBe("");
+
+      // Both clients insert
+      proxyA.text.insert(0, "A");
+      proxyB.text.insert(0, "B");
+      await waitMicrotask();
+
+      expect(proxyA.text).toHaveLength(2);
+      expect(proxyB.text).toHaveLength(2);
+    });
+
+    it("handles Unicode and emoji in collaborative editing", async () => {
+      const { proxyA, proxyB } = createRelayedProxiesMapRoot();
+
+      const text = syncedText("Hello 世界");
+      proxyA.text = text;
+      await waitMicrotask();
+
+      proxyA.text.insert(8, " 🌍");
+      proxyB.text.insert(0, "👋 ");
+      await waitMicrotask();
+
+      const contentA = proxyA.text.toString();
+      const contentB = proxyB.text.toString();
+
+      expect(contentA).toBe(contentB);
+      expect(contentA).toContain("👋");
+      expect(contentA).toContain("世界");
+      expect(contentA).toContain("🌍");
+    });
+
+    it("handles rapid delete and recreate of Y.Text", async () => {
+      const { proxyA, proxyB } = createRelayedProxiesMapRoot();
+
+      const text1 = syncedText("First");
+      proxyA.text = text1;
+      await waitMicrotask();
+
+      expect(proxyB.text.toString()).toBe("First");
+
+      // Delete and recreate
+      delete proxyA.text;
+      await waitMicrotask();
+
+      const text2 = syncedText("Second");
+      proxyA.text = text2;
+      await waitMicrotask();
+
+      expect(proxyB.text.toString()).toBe("Second");
+    });
+  });
+});

--- a/valtio-y/tests/integration/ytext-operations.spec.ts
+++ b/valtio-y/tests/integration/ytext-operations.spec.ts
@@ -1,0 +1,492 @@
+/* eslint @typescript-eslint/no-explicit-any: "off" */
+
+import { describe, expect, it } from "vitest";
+import * as Y from "yjs";
+import { createYjsProxy, syncedText } from "../../src/index";
+import {
+  createRelayedProxiesMapRoot,
+  waitMicrotask,
+} from "../helpers/test-helpers";
+import type { LooseRecord } from "../helpers/test-helpers";
+
+describe("Integration: Y.Text Operations", () => {
+  describe("Single Client Y.Text Operations", () => {
+    it("can insert Y.Text into a Y.Map via proxy", async () => {
+      const doc = new Y.Doc();
+      const { proxy } = createYjsProxy<LooseRecord>(doc, {
+        getRoot: (d) => d.getMap("root"),
+      });
+      const yRoot = doc.getMap<unknown>("root");
+
+      const text = syncedText("Hello World");
+      proxy.description = text;
+      await waitMicrotask();
+
+      const yText = yRoot.get("description");
+      expect(yText).toBeInstanceOf(Y.Text);
+      expect((yText as Y.Text).toString()).toBe("Hello World");
+    });
+
+    it("can insert Y.Text into a Y.Array via proxy", async () => {
+      const doc = new Y.Doc();
+      const { proxy } = createYjsProxy<Y.Text[]>(doc, {
+        getRoot: (d) => d.getArray("arr"),
+      });
+      const yArr = doc.getArray<Y.Text>("arr");
+
+      const text = syncedText("Array text");
+      proxy.push(text);
+      await waitMicrotask();
+
+      const yText = yArr.get(0);
+      expect(yText).toBeInstanceOf(Y.Text);
+      expect((yText as Y.Text).toString()).toBe("Array text");
+    });
+
+    it("Y.Text reference is accessible through proxy after assignment", async () => {
+      const doc = new Y.Doc();
+      const { proxy } = createYjsProxy<LooseRecord>(doc, {
+        getRoot: (d) => d.getMap("root"),
+      });
+
+      const text = syncedText("Initial");
+      proxy.text = text;
+      await waitMicrotask();
+
+      // The proxy should contain the Y.Text instance
+      expect(proxy.text).toBeInstanceOf(Y.Text);
+      expect(proxy.text.toString()).toBe("Initial");
+    });
+
+    it("can modify Y.Text content directly", async () => {
+      const doc = new Y.Doc();
+      const { proxy } = createYjsProxy<LooseRecord>(doc, {
+        getRoot: (d) => d.getMap("root"),
+      });
+      const yRoot = doc.getMap<unknown>("root");
+
+      const text = syncedText("Hello");
+      proxy.text = text;
+      await waitMicrotask();
+
+      // Modify the Y.Text directly
+      const yText = yRoot.get("text") as Y.Text;
+      yText.insert(5, " World");
+
+      expect(yText.toString()).toBe("Hello World");
+      // Proxy should reflect the same Y.Text instance
+      expect(proxy.text.toString()).toBe("Hello World");
+    });
+
+    it("can delete from Y.Text", async () => {
+      const doc = new Y.Doc();
+      const { proxy } = createYjsProxy<LooseRecord>(doc, {
+        getRoot: (d) => d.getMap("root"),
+      });
+
+      const text = syncedText("Hello World");
+      proxy.text = text;
+      await waitMicrotask();
+
+      // Delete " World" from the text
+      proxy.text.delete(5, 6);
+
+      expect(proxy.text.toString()).toBe("Hello");
+    });
+
+    it("can insert at specific positions in Y.Text", async () => {
+      const doc = new Y.Doc();
+      const { proxy } = createYjsProxy<LooseRecord>(doc, {
+        getRoot: (d) => d.getMap("root"),
+      });
+
+      const text = syncedText("Hello World");
+      proxy.text = text;
+      await waitMicrotask();
+
+      // Insert at position 6
+      proxy.text.insert(6, "Beautiful ");
+
+      expect(proxy.text.toString()).toBe("Hello Beautiful World");
+    });
+
+    it("can handle empty Y.Text", async () => {
+      const doc = new Y.Doc();
+      const { proxy } = createYjsProxy<LooseRecord>(doc, {
+        getRoot: (d) => d.getMap("root"),
+      });
+      const yRoot = doc.getMap<unknown>("root");
+
+      const text = syncedText();
+      proxy.text = text;
+      await waitMicrotask();
+
+      const yText = yRoot.get("text") as Y.Text;
+      expect(yText.toString()).toBe("");
+      expect(yText).toHaveLength(0);
+    });
+
+    it("can handle Y.Text with unicode characters", async () => {
+      const doc = new Y.Doc();
+      const { proxy } = createYjsProxy<LooseRecord>(doc, {
+        getRoot: (d) => d.getMap("root"),
+      });
+
+      const text = syncedText("Hello 👋 World 🌍");
+      proxy.text = text;
+      await waitMicrotask();
+
+      expect(proxy.text.toString()).toBe("Hello 👋 World 🌍");
+    });
+
+    it("can handle Y.Text with multiline content", async () => {
+      const doc = new Y.Doc();
+      const { proxy } = createYjsProxy<LooseRecord>(doc, {
+        getRoot: (d) => d.getMap("root"),
+      });
+
+      const content = "Line 1\nLine 2\nLine 3";
+      const text = syncedText(content);
+      proxy.text = text;
+      await waitMicrotask();
+
+      expect(proxy.text.toString()).toBe(content);
+    });
+  });
+
+  describe("Bootstrap with Y.Text", () => {
+    it("bootstrap creates proxy with Y.Text reference", () => {
+      const doc = new Y.Doc();
+      const yRoot = doc.getMap<unknown>("root");
+
+      // Setup Y.Text in document before creating proxy
+      const yText = new Y.Text("Existing content");
+      yRoot.set("description", yText);
+
+      const { proxy } = createYjsProxy<LooseRecord>(doc, {
+        getRoot: (d) => d.getMap("root"),
+      });
+
+      expect(proxy.description).toBeInstanceOf(Y.Text);
+      expect(proxy.description.toString()).toBe("Existing content");
+    });
+
+    it("bootstrap handles nested Y.Text in objects", () => {
+      const doc = new Y.Doc();
+      const yRoot = doc.getMap<unknown>("root");
+
+      const yNested = new Y.Map<unknown>();
+      const yText = new Y.Text("Nested text");
+      yNested.set("text", yText);
+      yRoot.set("nested", yNested);
+
+      const { proxy } = createYjsProxy<LooseRecord>(doc, {
+        getRoot: (d) => d.getMap("root"),
+      });
+
+      expect(proxy.nested.text).toBeInstanceOf(Y.Text);
+      expect(proxy.nested.text.toString()).toBe("Nested text");
+    });
+
+    it("bootstrap handles Y.Text in arrays", () => {
+      const doc = new Y.Doc();
+      const yArr = doc.getArray<Y.Text>("arr");
+
+      const yText = new Y.Text("Item text");
+      yArr.push([yText]);
+
+      const { proxy } = createYjsProxy<Y.Text[]>(doc, {
+        getRoot: (d) => d.getArray("arr"),
+      });
+
+      expect(proxy[0]).toBeInstanceOf(Y.Text);
+      expect(proxy[0]!.toString()).toBe("Item text");
+    });
+
+    it("bootstrap with multiple Y.Text instances", () => {
+      const doc = new Y.Doc();
+      const yRoot = doc.getMap<unknown>("root");
+
+      const yText1 = new Y.Text("First");
+      const yText2 = new Y.Text("Second");
+      yRoot.set("text1", yText1);
+      yRoot.set("text2", yText2);
+
+      const { proxy } = createYjsProxy<LooseRecord>(doc, {
+        getRoot: (d) => d.getMap("root"),
+      });
+
+      expect(proxy.text1.toString()).toBe("First");
+      expect(proxy.text2.toString()).toBe("Second");
+      expect(proxy.text1).not.toBe(proxy.text2);
+    });
+  });
+
+  describe("Remote Y.Text Changes", () => {
+    it("syncs Y.Text changes to proxy", () => {
+      const doc = new Y.Doc();
+      const yRoot = doc.getMap<unknown>("root");
+      const { proxy } = createYjsProxy<LooseRecord>(doc, {
+        getRoot: (d) => d.getMap("root"),
+      });
+
+      // Add Y.Text via Yjs directly (simulating remote change)
+      const yText = new Y.Text("Remote text");
+      yRoot.set("description", yText);
+
+      expect(proxy.description).toBeInstanceOf(Y.Text);
+      expect(proxy.description.toString()).toBe("Remote text");
+    });
+
+    it("proxy reflects direct Y.Text modifications", () => {
+      const doc = new Y.Doc();
+      const yRoot = doc.getMap<unknown>("root");
+      const yText = new Y.Text("Initial");
+      yRoot.set("text", yText);
+
+      const { proxy } = createYjsProxy<LooseRecord>(doc, {
+        getRoot: (d) => d.getMap("root"),
+      });
+
+      // Modify Y.Text directly (simulating remote change)
+      yText.insert(7, " content");
+
+      expect(proxy.text.toString()).toBe("Initial content");
+    });
+
+    it("proxy reflects Y.Text deletions", () => {
+      const doc = new Y.Doc();
+      const yRoot = doc.getMap<unknown>("root");
+      const yText = new Y.Text("Delete me");
+      yRoot.set("text", yText);
+
+      const { proxy } = createYjsProxy<LooseRecord>(doc, {
+        getRoot: (d) => d.getMap("root"),
+      });
+
+      // Delete from Y.Text (simulating remote change)
+      yText.delete(0, 7);
+
+      expect(proxy.text.toString()).toBe("me");
+    });
+  });
+
+  describe("Y.Text in Nested Structures", () => {
+    it("handles Y.Text in deeply nested maps", async () => {
+      const doc = new Y.Doc();
+      const { proxy } = createYjsProxy<LooseRecord>(doc, {
+        getRoot: (d) => d.getMap("root"),
+      });
+
+      proxy.level1 = { level2: { level3: {} } };
+      await waitMicrotask();
+
+      const text = syncedText("Deep text");
+      proxy.level1.level2.level3.text = text;
+      await waitMicrotask();
+
+      expect(proxy.level1.level2.level3.text).toBeInstanceOf(Y.Text);
+      expect(proxy.level1.level2.level3.text.toString()).toBe("Deep text");
+    });
+
+    it("handles Y.Text in nested arrays", async () => {
+      const doc = new Y.Doc();
+      const { proxy } = createYjsProxy<LooseRecord>(doc, {
+        getRoot: (d) => d.getMap("root"),
+      });
+
+      proxy.items = [[]];
+      await waitMicrotask();
+
+      const text = syncedText("Nested array text");
+      proxy.items[0].push(text);
+      await waitMicrotask();
+
+      expect(proxy.items[0][0]).toBeInstanceOf(Y.Text);
+      expect(proxy.items[0][0].toString()).toBe("Nested array text");
+    });
+
+    it("handles mixed structures with Y.Text", async () => {
+      const doc = new Y.Doc();
+      const { proxy } = createYjsProxy<LooseRecord>(doc, {
+        getRoot: (d) => d.getMap("root"),
+      });
+
+      proxy.document = {
+        title: "My Document",
+        sections: [],
+      };
+      await waitMicrotask();
+
+      const sectionText = syncedText("Section content");
+      proxy.document.sections.push({
+        heading: "Introduction",
+        content: sectionText,
+      });
+      await waitMicrotask();
+
+      expect(proxy.document.sections[0].content).toBeInstanceOf(Y.Text);
+      expect(proxy.document.sections[0].content.toString()).toBe(
+        "Section content",
+      );
+    });
+  });
+
+  describe("Y.Text Edge Cases", () => {
+    it("handles replacing Y.Text with another Y.Text", async () => {
+      const doc = new Y.Doc();
+      const { proxy } = createYjsProxy<LooseRecord>(doc, {
+        getRoot: (d) => d.getMap("root"),
+      });
+      const yRoot = doc.getMap<unknown>("root");
+
+      const text1 = syncedText("First");
+      proxy.text = text1;
+      await waitMicrotask();
+
+      const text2 = syncedText("Second");
+      proxy.text = text2;
+      await waitMicrotask();
+
+      const yText = yRoot.get("text") as Y.Text;
+      expect(yText.toString()).toBe("Second");
+      expect(proxy.text.toString()).toBe("Second");
+    });
+
+    it("handles deleting Y.Text from map", async () => {
+      const doc = new Y.Doc();
+      const { proxy } = createYjsProxy<LooseRecord>(doc, {
+        getRoot: (d) => d.getMap("root"),
+      });
+      const yRoot = doc.getMap<unknown>("root");
+
+      const text = syncedText("To be deleted");
+      proxy.text = text;
+      await waitMicrotask();
+
+      delete proxy.text;
+      await waitMicrotask();
+
+      expect(yRoot.has("text")).toBe(false);
+      expect(proxy.text).toBeUndefined();
+    });
+
+    it("handles removing Y.Text from array", async () => {
+      const doc = new Y.Doc();
+      const { proxy } = createYjsProxy<Y.Text[]>(doc, {
+        getRoot: (d) => d.getArray("arr"),
+      });
+      const yArr = doc.getArray<Y.Text>("arr");
+
+      const text = syncedText("Array item");
+      proxy.push(text);
+      await waitMicrotask();
+
+      proxy.splice(0, 1);
+      await waitMicrotask();
+
+      expect(yArr).toHaveLength(0);
+      expect(proxy).toHaveLength(0);
+    });
+
+    it("Y.Text operations are observable", () => {
+      const doc = new Y.Doc();
+      const yRoot = doc.getMap<unknown>("root");
+      const yText = new Y.Text("Initial");
+
+      // Y.Text must be in the document for observe to work
+      yRoot.set("text", yText);
+
+      let observeCount = 0;
+      yText.observe(() => {
+        observeCount++;
+      });
+
+      yText.insert(7, " text");
+      expect(observeCount).toBe(1);
+
+      yText.delete(0, 1);
+      expect(observeCount).toBe(2);
+    });
+
+    it("Y.Text persists and works correctly after modifications", async () => {
+      const doc = new Y.Doc();
+      const { proxy } = createYjsProxy<LooseRecord>(doc, {
+        getRoot: (d) => d.getMap("root"),
+      });
+
+      const text = syncedText("Hello");
+      proxy.text = text;
+      await waitMicrotask();
+
+      const reference1 = proxy.text;
+
+      // Modify the text
+      proxy.text.insert(5, " World");
+
+      const reference2 = proxy.text;
+
+      // Both should be Y.Text instances pointing to the same underlying Y.Text
+      // Note: They may be different proxy wrappers, but should have same content
+      expect(reference1).toBeInstanceOf(Y.Text);
+      expect(reference2).toBeInstanceOf(Y.Text);
+      expect(reference1.toString()).toBe("Hello World");
+      expect(reference2.toString()).toBe("Hello World");
+    });
+  });
+
+  describe("Y.Text Two-Client Collaboration", () => {
+    it("Y.Text changes sync between two clients", async () => {
+      const { proxyA, proxyB } = createRelayedProxiesMapRoot();
+
+      const text = syncedText("Shared text");
+      proxyA.text = text;
+      await waitMicrotask();
+
+      expect(proxyB.text).toBeInstanceOf(Y.Text);
+      expect(proxyB.text.toString()).toBe("Shared text");
+    });
+
+    it("concurrent Y.Text inserts merge correctly", async () => {
+      const { proxyA, proxyB } = createRelayedProxiesMapRoot();
+
+      // Setup shared Y.Text
+      const text = syncedText("");
+      proxyA.text = text;
+      await waitMicrotask();
+
+      // Concurrent inserts at different positions
+      proxyA.text.insert(0, "A");
+      proxyB.text.insert(0, "B");
+      await waitMicrotask();
+
+      // Both should have both characters (CRDT resolution)
+      const contentA = proxyA.text.toString();
+      const contentB = proxyB.text.toString();
+
+      expect(contentA).toBe(contentB);
+      expect(contentA).toHaveLength(2);
+      expect(contentA).toMatch(/[AB]{2}/);
+    });
+
+    it("Y.Text modifications sync in real-time", async () => {
+      const { proxyA, proxyB } = createRelayedProxiesMapRoot();
+
+      const text = syncedText("Initial");
+      proxyA.text = text;
+      await waitMicrotask();
+
+      // Client A appends
+      proxyA.text.insert(7, " text");
+      await waitMicrotask();
+
+      expect(proxyB.text.toString()).toBe("Initial text");
+
+      // Client B appends
+      proxyB.text.insert(12, " content");
+      await waitMicrotask();
+
+      expect(proxyA.text.toString()).toBe("Initial text content");
+    });
+  });
+});

--- a/valtio-y/tests/integration/ytext-reactivity-final.spec.tsx
+++ b/valtio-y/tests/integration/ytext-reactivity-final.spec.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import { render } from "vitest-browser-react";
+import * as Y from "yjs";
+import { createYjsProxy, syncedText } from "../../src";
+import { useSnapshot } from "valtio";
+
+describe("Y.Text Reactivity - Final Test", () => {
+  it("should re-render React component when Y.Text changes", async () => {
+    console.log("\n========== FINAL REACTIVITY TEST ==========\n");
+
+    const doc = new Y.Doc();
+
+    type State = {
+      text: Y.Text;
+    };
+
+    const { proxy, bootstrap } = createYjsProxy<State>(doc, {
+      getRoot: (doc) => doc.getMap("state"),
+    });
+
+    bootstrap({
+      text: syncedText("initial"),
+    });
+
+    let renderCount = 0;
+
+    function TestComponent() {
+      const snap = useSnapshot(proxy);
+      renderCount++;
+
+      const textContent = snap.text.toString();
+      console.log(`[RENDER #${renderCount}] text="${textContent}"`);
+
+      return (
+        <div>
+          <div data-testid="text">{textContent}</div>
+        </div>
+      );
+    }
+
+    console.log("=== Initial Render ===");
+    const screen = await render(<TestComponent />);
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const initialRenderCount = renderCount;
+    console.log("Initial render count:", initialRenderCount);
+
+    expect(screen.getByTestId("text")).toHaveTextContent("initial");
+
+    console.log("\n=== Modifying Y.Text ===");
+    proxy.text.delete(0, proxy.text.length);
+    proxy.text.insert(0, "updated");
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    console.log("Final render count:", renderCount);
+
+    expect(screen.getByTestId("text")).toHaveTextContent("updated");
+
+    expect(renderCount).toBeGreaterThan(initialRenderCount);
+    console.log(
+      `\n✅ SUCCESS: React re-rendered (${initialRenderCount} → ${renderCount})`,
+    );
+  });
+
+  it("should handle multiple sequential updates", async () => {
+    const doc = new Y.Doc();
+
+    type State = {
+      text: Y.Text;
+    };
+
+    const { proxy, bootstrap } = createYjsProxy<State>(doc, {
+      getRoot: (doc) => doc.getMap("state"),
+    });
+
+    bootstrap({
+      text: syncedText(""),
+    });
+
+    let renderCount = 0;
+    const renderLog: string[] = [];
+
+    function TestComponent() {
+      const snap = useSnapshot(proxy);
+      renderCount++;
+
+      const textContent = snap.text.toString();
+      renderLog.push(textContent);
+
+      return <div data-testid="text">{textContent}</div>;
+    }
+
+    const screen = await render(<TestComponent />);
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // Make several updates
+    proxy.text.insert(0, "a");
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    proxy.text.insert(1, "b");
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    proxy.text.insert(2, "c");
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    console.log("Render log:", renderLog);
+
+    expect(screen.getByTestId("text")).toHaveTextContent("abc");
+
+    // Should have re-rendered multiple times (initial + 3 updates)
+    expect(renderCount).toBeGreaterThanOrEqual(4);
+    console.log(`✅ SUCCESS: ${renderCount} renders for 3 updates`);
+  });
+});

--- a/valtio-y/tests/integration/ytext-reactivity.spec.tsx
+++ b/valtio-y/tests/integration/ytext-reactivity.spec.tsx
@@ -1,0 +1,209 @@
+import { describe, it, expect } from "vitest";
+import { render } from "vitest-browser-react";
+import * as Y from "yjs";
+import { createYjsProxy, syncedText } from "../../src";
+import { useSnapshot } from "valtio";
+
+describe("Y.Text Reactivity with React", () => {
+  it("updates React component when Y.Text content changes", async () => {
+    const doc = new Y.Doc();
+
+    type State = {
+      text: Y.Text;
+    };
+
+    const { proxy, bootstrap } = createYjsProxy<State>(doc, {
+      getRoot: (doc) => doc.getMap("state"),
+    });
+
+    bootstrap({
+      text: syncedText("Hello"),
+    });
+
+    // Create a React component that displays the Y.Text content
+    function TextDisplay() {
+      const snap = useSnapshot(proxy);
+      return (
+        <div>
+          <p data-testid="text-content">{snap.text.toString()}</p>
+        </div>
+      );
+    }
+
+    const screen = await render(<TextDisplay />);
+
+    // Initially should show "Hello"
+    expect(screen.getByTestId("text-content")).toHaveTextContent("Hello");
+
+    // Modify Y.Text directly (simulating user input)
+    proxy.text.insert(5, " World");
+
+    // The component should re-render and show the updated text
+    // This is the critical test - without the fix, this would timeout/fail
+    expect(screen.getByTestId("text-content")).toHaveTextContent("Hello World");
+  });
+
+  it("updates React component on Y.Text delete operations", async () => {
+    const doc = new Y.Doc();
+
+    type State = {
+      text: Y.Text;
+    };
+
+    const { proxy, bootstrap } = createYjsProxy<State>(doc, {
+      getRoot: (doc) => doc.getMap("state"),
+    });
+
+    bootstrap({
+      text: syncedText("Hello World"),
+    });
+
+    function TextDisplay() {
+      const snap = useSnapshot(proxy);
+      return <div data-testid="text-content">{snap.text.toString()}</div>;
+    }
+
+    const screen = await render(<TextDisplay />);
+
+    // Initially should show "Hello World"
+    expect(screen.getByTestId("text-content")).toHaveTextContent("Hello World");
+
+    // Delete part of the text
+    proxy.text.delete(5, 6); // Remove " World"
+
+    // Component should update immediately
+    expect(screen.getByTestId("text-content")).toHaveTextContent("Hello");
+  });
+
+  it("updates React component when Y.Text is modified from remote changes", async () => {
+    // Create two docs to simulate remote sync
+    const doc1 = new Y.Doc();
+    const doc2 = new Y.Doc();
+
+    type State = {
+      text: Y.Text;
+    };
+
+    const { proxy: proxy1, bootstrap } = createYjsProxy<State>(doc1, {
+      getRoot: (doc) => doc.getMap("state"),
+    });
+
+    const { proxy: proxy2 } = createYjsProxy<State>(doc2, {
+      getRoot: (doc) => doc.getMap("state"),
+    });
+
+    // Setup sync between docs BEFORE bootstrap to ensure initial state syncs
+    doc1.on("update", (update: Uint8Array) => {
+      Y.applyUpdate(doc2, update);
+    });
+
+    doc2.on("update", (update: Uint8Array) => {
+      Y.applyUpdate(doc1, update);
+    });
+
+    // Bootstrap after sync handlers are setup
+    bootstrap({
+      text: syncedText("Initial"),
+    });
+
+    // Wait for initial sync to propagate
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // Component uses proxy2 but changes come from proxy1
+    function TextDisplay() {
+      const snap = useSnapshot(proxy2);
+      return (
+        <div data-testid="remote-text">
+          {snap.text?.toString() || "loading..."}
+        </div>
+      );
+    }
+
+    const screen = await render(<TextDisplay />);
+
+    // Initially should show "Initial"
+    expect(screen.getByTestId("remote-text")).toHaveTextContent("Initial");
+
+    // Modify via proxy1 (remote change)
+    proxy1.text.insert(7, " Text");
+
+    // Component watching proxy2 should update
+    expect(screen.getByTestId("remote-text")).toHaveTextContent("Initial Text");
+  });
+
+  it("handles multiple rapid Y.Text changes", async () => {
+    const doc = new Y.Doc();
+
+    type State = {
+      text: Y.Text;
+    };
+
+    const { proxy, bootstrap } = createYjsProxy<State>(doc, {
+      getRoot: (doc) => doc.getMap("state"),
+    });
+
+    bootstrap({
+      text: syncedText(""),
+    });
+
+    function TextDisplay() {
+      const snap = useSnapshot(proxy);
+      return (
+        <div>
+          <div data-testid="text-content">{snap.text.toString()}</div>
+          <div data-testid="text-length">{snap.text.length}</div>
+        </div>
+      );
+    }
+
+    const screen = await render(<TextDisplay />);
+
+    // Perform multiple rapid inserts
+    proxy.text.insert(0, "H");
+    proxy.text.insert(1, "e");
+    proxy.text.insert(2, "l");
+    proxy.text.insert(3, "l");
+    proxy.text.insert(4, "o");
+
+    // Component should eventually show all changes
+    expect(screen.getByTestId("text-content")).toHaveTextContent("Hello");
+    expect(screen.getByTestId("text-length")).toHaveTextContent("5");
+  });
+
+  it("displays character count that updates reactively", async () => {
+    const doc = new Y.Doc();
+
+    type State = {
+      text: Y.Text;
+    };
+
+    const { proxy, bootstrap } = createYjsProxy<State>(doc, {
+      getRoot: (doc) => doc.getMap("state"),
+    });
+
+    bootstrap({
+      text: syncedText("Test"),
+    });
+
+    function CharacterCounter() {
+      const snap = useSnapshot(proxy);
+      const count = snap.text.length;
+      return (
+        <div>
+          <p data-testid="char-count">Characters: {count}</p>
+        </div>
+      );
+    }
+
+    const screen = await render(<CharacterCounter />);
+
+    // Initial count
+    expect(screen.getByTestId("char-count")).toHaveTextContent("Characters: 4");
+
+    // Add more text
+    proxy.text.insert(4, " Text");
+
+    // Count should update
+    expect(screen.getByTestId("char-count")).toHaveTextContent("Characters: 9");
+  });
+});

--- a/valtio-y/tests/integration/ytext-simple-usesnapshot.spec.tsx
+++ b/valtio-y/tests/integration/ytext-simple-usesnapshot.spec.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { render } from "vitest-browser-react";
+import * as Y from "yjs";
+import { createYjsProxy, syncedText } from "../../src";
+import { useSnapshot, subscribe } from "valtio";
+
+describe("Y.Text Simple useSnapshot Test", () => {
+  it("should re-render when Y.Text changes (minimal test)", async () => {
+    const doc = new Y.Doc();
+
+    type State = {
+      text: Y.Text;
+    };
+
+    const { proxy, bootstrap } = createYjsProxy<State>(doc, {
+      getRoot: (doc) => doc.getMap("state"),
+      debug: true, // Enable debug logging
+    });
+
+    bootstrap({
+      text: syncedText(""),
+    });
+
+    // Add explicit subscription BEFORE rendering component
+    subscribe(proxy, () => {
+      console.log("[SUBSCRIBE] Proxy changed");
+    });
+
+    let renderCount = 0;
+
+    function TestComponent() {
+      const snap = useSnapshot(proxy);
+      renderCount++;
+
+      // NO explicit version access needed - the reactive wrapper handles it!
+      const textContent = snap.text.toString();
+      console.log(`[RENDER #${renderCount}] text="${textContent}"`);
+
+      return (
+        <div>
+          <div data-testid="text">{textContent}</div>
+        </div>
+      );
+    }
+
+    const screen = await render(<TestComponent />);
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const initialRenderCount = renderCount;
+    console.log("Initial render count:", initialRenderCount);
+
+    // Modify Y.Text
+    console.log('\n=== Inserting "hello" ===');
+    proxy.text.insert(0, "hello");
+
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    console.log("Final render count:", renderCount);
+
+    // Should have re-rendered
+    expect(renderCount).toBeGreaterThan(initialRenderCount);
+
+    const textElement = screen.getByTestId("text");
+    expect(textElement).toHaveTextContent("hello");
+
+    console.log(
+      `✅ SUCCESS: React re-rendered (${initialRenderCount} → ${renderCount})`,
+    );
+  });
+});

--- a/valtio-y/tests/integration/ytext-typing-sequential.spec.tsx
+++ b/valtio-y/tests/integration/ytext-typing-sequential.spec.tsx
@@ -1,0 +1,391 @@
+import { describe, it, expect } from "vitest";
+import { render } from "vitest-browser-react";
+import * as Y from "yjs";
+import { createYjsProxy, syncedText } from "../../src";
+import { useSnapshot } from "valtio";
+import React, { useRef } from "react";
+import { userEvent } from "vitest/browser";
+
+describe("Y.Text Sequential Typing - Definitive Test", () => {
+  /**
+   * This test definitively proves that typing "hello" character by character works.
+   *
+   * Key points:
+   * - Uses controlled textarea with proper React patterns
+   * - Simulates real user typing using CDP (not mocked)
+   * - Verifies each character appears correctly
+   * - Tracks render counts to detect double-rendering issues
+   * - Confirms Y.Text internal state matches DOM state
+   */
+  it('should handle typing "hello" character by character', async () => {
+    const doc = new Y.Doc();
+
+    type State = {
+      text: Y.Text;
+    };
+
+    const { proxy, bootstrap } = createYjsProxy<State>(doc, {
+      getRoot: (doc) => doc.getMap("state"),
+    });
+
+    bootstrap({
+      text: syncedText(""),
+    });
+
+    const renderLog: string[] = [];
+    const changeLog: string[] = [];
+
+    function ControlledTextarea() {
+      const snap = useSnapshot(proxy);
+      const textContent = snap.text.toString();
+      const renderCountRef = useRef(0);
+      renderCountRef.current += 1;
+
+      renderLog.push(`render #${renderCountRef.current}: "${textContent}"`);
+
+      const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+        const newValue = e.currentTarget.value;
+        const oldValue = proxy.text.toString();
+
+        changeLog.push(`onChange: "${oldValue}" → "${newValue}"`);
+
+        // Simple append-only logic (for this test we only add characters)
+        if (newValue.length > oldValue.length) {
+          const inserted = newValue.substring(oldValue.length);
+          proxy.text.insert(oldValue.length, inserted);
+        } else if (newValue.length < oldValue.length) {
+          // Handle deletion
+          const deleteCount = oldValue.length - newValue.length;
+          proxy.text.delete(newValue.length, deleteCount);
+        }
+      };
+
+      return (
+        <div>
+          <textarea
+            data-testid="controlled-textarea"
+            value={textContent}
+            onChange={handleChange}
+            placeholder="Type here..."
+          />
+          <div data-testid="display">{textContent}</div>
+          <div data-testid="render-count">{renderCountRef.current}</div>
+          <div data-testid="ytext-value">{proxy.text.toString()}</div>
+        </div>
+      );
+    }
+
+    const screen = await render(<ControlledTextarea />);
+    const textarea = screen.getByTestId("controlled-textarea");
+
+    console.log("\n=== INITIAL STATE ===");
+    expect(textarea).toHaveValue("");
+    expect(screen.getByTestId("display")).toHaveTextContent("");
+    console.log("✓ Initial state correct");
+
+    // Clear logs after initial render
+    renderLog.length = 0;
+    changeLog.length = 0;
+
+    // TYPE: 'h'
+    console.log('\n=== TYPING "h" ===');
+    await textarea.click(); // Focus first
+    await userEvent.keyboard("h");
+
+    // Wait for React to process
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    console.log("Render log:", renderLog);
+    console.log("Change log:", changeLog);
+
+    expect(textarea).toHaveValue("h");
+    expect(screen.getByTestId("display")).toHaveTextContent("h");
+    expect(proxy.text.toString()).toBe("h");
+    console.log('✓ "h" successful');
+
+    renderLog.length = 0;
+    changeLog.length = 0;
+
+    // TYPE: 'e'
+    console.log('\n=== TYPING "e" ===');
+    await userEvent.keyboard("e");
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    console.log("Render log:", renderLog);
+    console.log("Change log:", changeLog);
+
+    expect(textarea).toHaveValue("he");
+    expect(screen.getByTestId("display")).toHaveTextContent("he");
+    expect(proxy.text.toString()).toBe("he");
+    console.log('✓ "he" successful');
+
+    renderLog.length = 0;
+    changeLog.length = 0;
+
+    // TYPE: 'l'
+    console.log('\n=== TYPING "l" ===');
+    await userEvent.keyboard("l");
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    console.log("Render log:", renderLog);
+    console.log("Change log:", changeLog);
+
+    expect(textarea).toHaveValue("hel");
+    expect(screen.getByTestId("display")).toHaveTextContent("hel");
+    expect(proxy.text.toString()).toBe("hel");
+    console.log('✓ "hel" successful');
+
+    renderLog.length = 0;
+    changeLog.length = 0;
+
+    // TYPE: 'l'
+    console.log('\n=== TYPING second "l" ===');
+    await userEvent.keyboard("l");
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    console.log("Render log:", renderLog);
+    console.log("Change log:", changeLog);
+
+    expect(textarea).toHaveValue("hell");
+    expect(screen.getByTestId("display")).toHaveTextContent("hell");
+    expect(proxy.text.toString()).toBe("hell");
+    console.log('✓ "hell" successful');
+
+    renderLog.length = 0;
+    changeLog.length = 0;
+
+    // TYPE: 'o'
+    console.log('\n=== TYPING "o" ===');
+    await userEvent.keyboard("o");
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    console.log("Render log:", renderLog);
+    console.log("Change log:", changeLog);
+
+    expect(textarea).toHaveValue("hello");
+    expect(screen.getByTestId("display")).toHaveTextContent("hello");
+    expect(proxy.text.toString()).toBe("hello");
+    console.log('✓ "hello" successful');
+
+    console.log("\n=== SUCCESS: All 5 characters typed successfully ===");
+  });
+
+  /**
+   * Alternative test using .fill() to progressively build the string.
+   * This verifies that even with .fill() (which replaces the entire value),
+   * the controlled component pattern works correctly.
+   */
+  it("should handle progressive .fill() calls", async () => {
+    const doc = new Y.Doc();
+
+    type State = {
+      text: Y.Text;
+    };
+
+    const { proxy, bootstrap } = createYjsProxy<State>(doc, {
+      getRoot: (doc) => doc.getMap("state"),
+    });
+
+    bootstrap({
+      text: syncedText(""),
+    });
+
+    let renderCount = 0;
+    let onChangeCount = 0;
+
+    function TestComponent() {
+      const snap = useSnapshot(proxy);
+      const textContent = snap.text.toString();
+      // eslint-disable-next-line react-hooks/react-compiler
+      renderCount += 1;
+
+      const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+        onChangeCount += 1;
+        const newValue = e.currentTarget.value;
+        const oldValue = proxy.text.toString();
+
+        // Handle both insertions and replacements
+        if (newValue.length > oldValue.length) {
+          const inserted = newValue.substring(oldValue.length);
+          proxy.text.insert(oldValue.length, inserted);
+        } else if (newValue.length < oldValue.length) {
+          const deleteCount = oldValue.length - newValue.length;
+          proxy.text.delete(newValue.length, deleteCount);
+        } else if (newValue !== oldValue) {
+          // Complete replacement
+          proxy.text.delete(0, oldValue.length);
+          proxy.text.insert(0, newValue);
+        }
+      };
+
+      return (
+        <div>
+          <textarea
+            data-testid="textarea"
+            value={textContent}
+            onChange={handleChange}
+          />
+          <div data-testid="display">{textContent}</div>
+          <div data-testid="onChange-count">{onChangeCount}</div>
+          <div data-testid="render-count">{renderCount}</div>
+        </div>
+      );
+    }
+
+    const screen = await render(<TestComponent />);
+    const textarea = screen.getByTestId("textarea");
+
+    // Initial state
+    const initialRenderCount = renderCount;
+    console.log("\n=== Initial render count:", initialRenderCount);
+
+    // Progressive fills
+    console.log('\n=== Fill with "h" ===');
+    await textarea.fill("h");
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(textarea).toHaveValue("h");
+    expect(proxy.text.toString()).toBe("h");
+    console.log("onChange count:", onChangeCount, "render count:", renderCount);
+
+    console.log('\n=== Fill with "he" ===');
+    await textarea.fill("he");
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(textarea).toHaveValue("he");
+    expect(proxy.text.toString()).toBe("he");
+    console.log("onChange count:", onChangeCount, "render count:", renderCount);
+
+    console.log('\n=== Fill with "hel" ===');
+    await textarea.fill("hel");
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(textarea).toHaveValue("hel");
+    expect(proxy.text.toString()).toBe("hel");
+    console.log("onChange count:", onChangeCount, "render count:", renderCount);
+
+    console.log('\n=== Fill with "hell" ===');
+    await textarea.fill("hell");
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(textarea).toHaveValue("hell");
+    expect(proxy.text.toString()).toBe("hell");
+    console.log("onChange count:", onChangeCount, "render count:", renderCount);
+
+    console.log('\n=== Fill with "hello" ===');
+    await textarea.fill("hello");
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(textarea).toHaveValue("hello");
+    expect(proxy.text.toString()).toBe("hello");
+    console.log("onChange count:", onChangeCount, "render count:", renderCount);
+
+    // Final assertions
+    console.log("\n=== FINAL STATE ===");
+    console.log("Total onChange calls:", onChangeCount);
+    console.log("Total renders:", renderCount);
+    console.log("Expected onChange: 5 (one per fill)");
+    console.log(
+      "Expected renders: ~10-15 (initial + after each Y.Text change)",
+    );
+
+    // onChange should be called once per .fill()
+    expect(onChangeCount).toBe(5);
+
+    // Final state should be correct
+    expect(textarea).toHaveValue("hello");
+    expect(screen.getByTestId("display")).toHaveTextContent("hello");
+    expect(proxy.text.toString()).toBe("hello");
+
+    console.log("\n=== SUCCESS: Progressive fills work correctly ===");
+  });
+
+  /**
+   * Test to verify that observer is only registered ONCE per Y.Text change.
+   * This directly tests the reconciler fix.
+   */
+  it("should only trigger ONE observer call per Y.Text modification", async () => {
+    const doc = new Y.Doc();
+
+    type State = {
+      text: Y.Text;
+    };
+
+    const { proxy, bootstrap } = createYjsProxy<State>(doc, {
+      getRoot: (doc) => doc.getMap("state"),
+    });
+
+    bootstrap({
+      text: syncedText(""),
+    });
+
+    // Track observer calls
+    let observerCallCount = 0;
+    const observerLog: string[] = [];
+
+    // Add our own observer to verify behavior
+    proxy.text.observe((event) => {
+      observerCallCount++;
+      observerLog.push(
+        `Observer called #${observerCallCount}, changes: ${event.changes.delta.length}`,
+      );
+    });
+
+    function TestComponent() {
+      const snap = useSnapshot(proxy);
+      const textContent = snap.text.toString();
+
+      const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+        const newValue = e.currentTarget.value;
+        const oldValue = proxy.text.toString();
+
+        if (newValue.length > oldValue.length) {
+          const inserted = newValue.substring(oldValue.length);
+          proxy.text.insert(oldValue.length, inserted);
+        }
+      };
+
+      return (
+        <textarea
+          data-testid="textarea"
+          value={textContent}
+          onChange={handleChange}
+        />
+      );
+    }
+
+    const screen = await render(<TestComponent />);
+    const textarea = screen.getByTestId("textarea");
+
+    console.log("\n=== Testing observer call frequency ===");
+
+    // Reset counter
+    observerCallCount = 0;
+    observerLog.length = 0;
+
+    // Type one character
+    await textarea.fill("x");
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    console.log('Observer log after typing "x":', observerLog);
+    console.log("Observer call count:", observerCallCount);
+    console.log("Expected: 1 (CRITICAL: if this is 2, the bug still exists!)");
+
+    // CRITICAL ASSERTION: Should be exactly 1
+    expect(observerCallCount).toBe(1);
+
+    // Reset for second character
+    observerCallCount = 0;
+    observerLog.length = 0;
+
+    // Type second character
+    await textarea.fill("xy");
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    console.log('Observer log after typing "y":', observerLog);
+    console.log("Observer call count:", observerCallCount);
+    console.log("Expected: 1");
+
+    // Should still be exactly 1
+    expect(observerCallCount).toBe(1);
+
+    console.log(
+      "\n=== SUCCESS: Each Y.Text change triggers exactly ONE observer call ===",
+    );
+  });
+});


### PR DESCRIPTION
Experimental implementation of Y.Text, Y.XmlFragment, Y.XmlElement, and Y.XmlHook support for collaborative text editing and structured content use cases.

This research explores integrating Yjs leaf types (Y.Text and XML) with Valtio's reactive system for non-editor use cases. Note that production text editors should use native Yjs integrations (Lexical, TipTap, ProseMirror) which are optimized for their specific needs.

Features:
- Y.Text reactive integration with automatic version tracking
- XML types (XmlFragment, XmlElement, XmlHook) support
- Comprehensive test suite (E2E, integration, typing tests)
- Example application: examples/06_ytext/
- Property-based testing with fast-check

Status: Research branch - exploring feasibility and use cases.
