### PR TITLE
Fix validation test reference in architecture docs

### DIFF
--- a/docs/architecture/architectural-decisions.md
+++ b/docs/architecture/architectural-decisions.md
@@ -123,7 +123,7 @@
   - Eliminates unhandled promise rejections from async validation
   - Provides clear error messages at the point of invalid assignment
   - Enables defensive programming patterns with try/catch
-- Test Coverage: See `tests/map-validation-rollback.spec.ts` for comprehensive validation scenarios
+- Test Coverage: See `valtio-y/tests/integration/error-handling.spec.ts` ("Map Validation and Rollback" suite) for comprehensive validation scenarios
 
 ## 11) No Implicit Type Conversions (Date, RegExp, etc.)
 


### PR DESCRIPTION
## Summary
- update the architectural decisions documentation to point to the existing validation rollback tests

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69067d61ab748322beb25d6d06e8233d