### PR TITLE
fix(ci): remove npm provenance flag to fix publish workflow

### DIFF
--- a/valtio-y/package.json
+++ b/valtio-y/package.json
@@ -35,7 +35,7 @@
     "test": "bun vitest",
     "bench": "bun vitest bench --config vitest.bench.config.ts",
     "typecheck": "bun tsc -b --emitDeclarationOnly",
-    "publish": "npm publish --access public --provenance"
+    "publish": "npm publish --access public"
   },
   "keywords": [
     "valtio",


### PR DESCRIPTION
## Summary

- Removes `--provenance` flag from npm publish command in `valtio-y/package.json:38`
- Fixes publish workflow failure: "Automatic provenance generation not supported for provider: null"

## Root Cause

The npm provenance feature requires GitHub Actions environment detection that wasn't working properly in the current workflow setup. This caused all publish attempts to fail.

## Solution

Remove the `--provenance` flag for now. Provenance is a supply chain attestation feature that's nice-to-have but not essential. It can be re-added later with proper Node.js environment configuration if needed.

## Test Plan

- [ ] Verify CI passes
- [ ] Merge to main and test that the release workflow can publish successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)