### PR TITLE
chore(repo): rename VALTIO_YJS_ORIGIN to VALTIO_Y_ORIGIN

### DIFF
--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -28,7 +28,7 @@ Public API (bridge)  Controller Proxy Layer (how)   Synchronization Layer       
 ```
 
 - Public API Layer (the bridge entrypoint): `createYjsProxy(doc, { getRoot })` creates the root controller proxy (the Valtio proxy for the chosen Y root), instantiates a coordinator to orchestrate all components, sets up sync, and returns `{ proxy, dispose, bootstrap }`.
-- Controller Layer: A tree of Valtio proxies mirrors `Y.Map`/`Y.Array`. Local mutations enqueue direct-child ops into the coordinator's Write Scheduler; the scheduler flushes them in one `doc.transact(…, VALTIO_YJS_ORIGIN)` per microtask.
+- Controller Layer: A tree of Valtio proxies mirrors `Y.Map`/`Y.Array`. Local mutations enqueue direct-child ops into the coordinator's Write Scheduler; the scheduler flushes them in one `doc.transact(…, VALTIO_Y_ORIGIN)` per microtask.
 - Synchronization Layer: A root-scoped deep observer (`yRoot.observeDeep`) handles inbound updates. It ignores library-origin transactions and reconciles the nearest materialized ancestor for each event.
 - Type Conversion Layer: Pure utilities convert plain JS data to Yjs types and vice versa.
 

--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -7,10 +7,10 @@ Scenario: `userProxy.profile.email = '...'` in the UI.
 1. Accessing `profile` returns the `profile` controller proxy (a Valtio proxy for a `Y.Map`). This proxy is the object you use; it performs the controller behavior under the hood.
 2. The Valtio subscription on the object proxy receives a top-level `set` operation for `email`.
 3. The operation is enqueued into the coordinator's write scheduler.
-4. On the next microtask, the scheduler flushes all pending operations in a single `doc.transact(..., VALTIO_YJS_ORIGIN)`.
+4. On the next microtask, the scheduler flushes all pending operations in a single `doc.transact(..., VALTIO_Y_ORIGIN)`.
 5. Inside the transaction, `yProfileMap.set('email', '...')` is called (or convert complex values using converter utilities if needed).
 6. The transaction ends.
-7. `yRoot.observeDeep` callback fires, but the handler ignores it because `transaction.origin === VALTIO_YJS_ORIGIN`.
+7. `yRoot.observeDeep` callback fires, but the handler ignores it because `transaction.origin === VALTIO_Y_ORIGIN`.
 8. `doc.on('update')` may fire via the provider and propagate to peers.
 
 Note: When assigning a plain object/array into a controller proxy, the system eagerly upgrades it to a Y type during planning. After the scheduler's transaction completes and the Y type is fully integrated, post-transaction callbacks replace the plain value with a live controller proxy under a reconciliation lock. This ensures the controller is created only after the Y value exists and keeps nested edits encapsulated within the child controller proxy, avoiding parent-level routing.
@@ -21,7 +21,7 @@ Scenario: A peer inserts a new item into a shared list (a `Y.Array`).
 
 1. The provider applies the update: `Y.applyUpdate(doc, update)`.
 2. `yRoot.observeDeep` callback fires with events and a transaction object.
-3. The synchronizer checks `transaction.origin !== VALTIO_YJS_ORIGIN` (to ignore our own changes) and processes the events.
+3. The synchronizer checks `transaction.origin !== VALTIO_Y_ORIGIN` (to ignore our own changes) and processes the events.
 4. For each event, it walks up to find the nearest materialized ancestor (boundary).
 5. Two-phase reconciliation:
    - Phase 1: Reconcile boundaries to ensure structure and materialize controller proxies for new Y types.

--- a/guides/undo-redo.md
+++ b/guides/undo-redo.md
@@ -200,11 +200,11 @@ window.addEventListener("keydown", (e) => {
 ### Track Only Local Changes (Multi-User)
 
 ```typescript
-import { VALTIO_YJS_ORIGIN } from "valtio-y";
+import { VALTIO_Y_ORIGIN } from "valtio-y";
 
 // Track only this client's changes (ignore remote users)
 const undoManager = new UndoManager(ydoc.getMap("state"), {
-  trackedOrigins: new Set([VALTIO_YJS_ORIGIN]),
+  trackedOrigins: new Set([VALTIO_Y_ORIGIN]),
 });
 ```
 

--- a/valtio-y/src/bridge/valtio-bridge.ts
+++ b/valtio-y/src/bridge/valtio-bridge.ts
@@ -4,7 +4,7 @@
 // - Materialize real Valtio proxies for Yjs shared types (currently Y.Map).
 // - Maintain stable identity via caches (Y type <-> Valtio proxy) inside a context.
 // - Reflect local Valtio writes back to Yjs minimally (set/delete) inside
-//   transactions tagged with VALTIO_YJS_ORIGIN.
+//   transactions tagged with VALTIO_Y_ORIGIN.
 // - Lazily create nested controllers when a Y value is another Y type.
 import * as Y from "yjs";
 import { proxy, subscribe } from "valtio/vanilla";

--- a/valtio-y/src/core/constants.ts
+++ b/valtio-y/src/core/constants.ts
@@ -1,5 +1,5 @@
 // Unique symbol used as the transaction origin for our own updates
-export const VALTIO_YJS_ORIGIN: unique symbol = Symbol("valtio-y-origin");
+export const VALTIO_Y_ORIGIN: unique symbol = Symbol("valtio-y-origin");
 
 // Shared prefix for all debug logs
 export const LOG_PREFIX = "[valtio-y]";

--- a/valtio-y/src/create-yjs-proxy.ts
+++ b/valtio-y/src/create-yjs-proxy.ts
@@ -5,7 +5,7 @@ import {
   plainObjectToYType,
   validateDeepForSharedState,
 } from "./core/converter";
-import { VALTIO_YJS_ORIGIN } from "./core/constants";
+import { VALTIO_Y_ORIGIN } from "./core/constants";
 import { ValtioYjsCoordinator } from "./core/coordinator";
 import { isYArray, isYMap } from "./core/guards";
 import {
@@ -138,7 +138,7 @@ export function createYjsProxy<T extends object>(
         for (const [key, converted] of convertedEntries) {
           yRoot.set(key, converted);
         }
-      }, VALTIO_YJS_ORIGIN);
+      }, VALTIO_Y_ORIGIN);
     } else if (isYArray(yRoot)) {
       const items = (data as unknown as unknown[]).map((v) => {
         validateDeepForSharedState(v);
@@ -146,7 +146,7 @@ export function createYjsProxy<T extends object>(
       });
       doc.transact(() => {
         if (items.length > 0) yRoot.insert(0, items);
-      }, VALTIO_YJS_ORIGIN);
+      }, VALTIO_Y_ORIGIN);
     }
 
     // Our listener ignores our origin to avoid loops, so we must explicitly

--- a/valtio-y/src/index.ts
+++ b/valtio-y/src/index.ts
@@ -9,7 +9,7 @@ export { createYjsProxy } from "./create-yjs-proxy";
 export type { CreateYjsProxyOptions, YjsProxy } from "./create-yjs-proxy";
 
 // Constants
-export { VALTIO_YJS_ORIGIN } from "./core/constants";
+export { VALTIO_Y_ORIGIN } from "./core/constants";
 
 // Type utilities for advanced users
 export type {

--- a/valtio-y/src/scheduling/write-scheduler.ts
+++ b/valtio-y/src/scheduling/write-scheduler.ts
@@ -1,7 +1,7 @@
 import * as Y from "yjs";
 import type { PendingMapEntry, PendingArrayEntry } from "./batch-types";
 import type { Logger } from "../core/logger";
-import { VALTIO_YJS_ORIGIN } from "../core/constants";
+import { VALTIO_Y_ORIGIN } from "../core/constants";
 import { PostTransactionQueue } from "./post-transaction-queue";
 
 /**
@@ -465,7 +465,7 @@ export class WriteScheduler {
         postQueue,
         this.applyFunctions.withReconcilingLock,
       );
-    }, VALTIO_YJS_ORIGIN);
+    }, VALTIO_Y_ORIGIN);
 
     // Flush post-transaction callbacks with reconciling lock
     postQueue.flush(this.applyFunctions.withReconcilingLock);

--- a/valtio-y/src/synchronizer.ts
+++ b/valtio-y/src/synchronizer.ts
@@ -2,11 +2,11 @@
 //
 // Responsibility:
 // - Listen to Yjs deep events and trigger reconciliation.
-// - Ignore transactions with our origin (VALTIO_YJS_ORIGIN) to prevent loops.
+// - Ignore transactions with our origin (VALTIO_Y_ORIGIN) to prevent loops.
 // - For each deep event, walk up to the nearest materialized ancestor and
 //   reconcile that container to support lazy materialization.
 import * as Y from "yjs";
-import { VALTIO_YJS_ORIGIN } from "./core/constants";
+import { VALTIO_Y_ORIGIN } from "./core/constants";
 import {
   reconcileValtioMap,
   reconcileValtioArray,
@@ -37,7 +37,7 @@ export function setupSyncListener(
     events: Y.YEvent<Y.AbstractType<unknown>>[],
     transaction: Y.Transaction,
   ) => {
-    if (transaction.origin === VALTIO_YJS_ORIGIN) {
+    if (transaction.origin === VALTIO_Y_ORIGIN) {
       return;
     }
     coordinator.logger.debug("[sync] deep", {


### PR DESCRIPTION
## Summary

Renames the constant `VALTIO_YJS_ORIGIN` to `VALTIO_Y_ORIGIN` to match the package naming convention (`valtio-y`).

## Changes

- Renamed constant definition in `valtio-y/src/core/constants.ts`
- Updated all imports and usages across source files
- Updated export in `valtio-y/src/index.ts`
- Updated documentation in `docs/architecture/` 
- Updated guide in `guides/undo-redo.md`

## Testing

- ✅ All tests pass (459 passed, 1 skipped)
- ✅ TypeScript type checking passes
- ✅ Linting passes with no new errors

## Checklist

- [x] Code changes implemented
- [x] All tests pass
- [x] TypeScript type checking passes
- [x] Linting passes
- [x] Documentation updated