### PR TITLE
chore(docs): Implement valtio-y documentation improvements

### DIFF
--- a/valtio-y/src/reconcile/reconciler.ts
+++ b/valtio-y/src/reconcile/reconciler.ts
@@ -208,8 +208,14 @@ export function reconcileValtioMap(
   });
 }
 
-// TODO: Implement granular delta-based reconciliation for arrays.
-// For now, perform a coarse structural sync using splice.
+/**
+ * Performs coarse structural reconciliation for arrays.
+ * Granular delta-based reconciliation is handled by reconcileValtioArrayWithDelta().
+ * This function is used when:
+ * - Initial materialization of an array
+ * - No delta is available (e.g., applying state vector)
+ * - Structural reconciliation is needed for deeply nested arrays
+ */
 export function reconcileValtioArray(
   coordinator: ValtioYjsCoordinator,
   yArray: Y.Array<unknown>,

--- a/valtio-y/src/scheduling/array-apply.ts
+++ b/valtio-y/src/scheduling/array-apply.ts
@@ -223,6 +223,10 @@ function handleSets(
       index >= lengthAtStart ||
       index >= firstDeleteIndex ||
       index >= yArray.length;
+    // Use current yArray.length (modified by replaces/deletes) for clamping instead of
+    // lengthAtStart because we want to insert at the safest position given the current
+    // array state. This prevents index-out-of-bounds errors in edge cases where complex
+    // operation sequences might create temporary inconsistencies.
     const targetIndex = shouldAppend
       ? tailCursor
       : Math.min(Math.max(index, 0), yArray.length);


### PR DESCRIPTION
…tails

- Remove stale TODO comment in reconciler.ts - granular delta reconciliation is already implemented via reconcileValtioArrayWithDelta()
- Document out-of-bounds clamping behavior in array-apply.ts explaining why current yArray.length is used instead of lengthAtStart to prevent index-out-of-bounds errors in edge cases

These documentation improvements clarify existing implementation decisions for future maintainers.