### PR TITLE
fix(tests): replace .length).toBe() with toHaveLength() in multiple-roots test

### DIFF
--- a/valtio-y/tests/integration/multiple-roots.spec.ts
+++ b/valtio-y/tests/integration/multiple-roots.spec.ts
@@ -77,7 +77,7 @@ describe("Multiple Root Proxies", () => {
 
     // Verify Y structures are separate
     expect(doc.getMap("settings").get("theme")).toBe("dark");
-    expect(doc.getArray("tasks").length).toBe(2);
+    expect(doc.getArray("tasks")).toHaveLength(2);
     expect(doc.getMap("metadata").get("version")).toBe(1);
   });
 


### PR DESCRIPTION
Fixes a linting error by replacing `.length).toBe()` with the preferred Jest matcher `.toHaveLength()`.

This change resolves the `eslint-plugin-jest(prefer-to-have-length)` error that was causing the lint command to fail.