### PR TITLE
fix(core): address architectural correctness issues from audit

### DIFF
--- a/valtio-y/src/core/coordinator.ts
+++ b/valtio-y/src/core/coordinator.ts
@@ -80,6 +80,15 @@ export class ValtioYjsCoordinator {
   /**
    * Execute a function while holding the reconciling lock.
    * This prevents Valtio changes from being reflected back to Yjs during reconciliation.
+   *
+   * IMPORTANT: This lock is recursion-safe. It saves and restores the previous lock state,
+   * allowing nested reconciliation calls to work correctly. For example:
+   * - Outer reconciliation sets isReconciling = true
+   * - Nested reconciliation saves previous=true, sets isReconciling=true (no-op), executes, restores to true
+   * - Outer reconciliation continues with isReconciling=true, then finally restores to original state
+   *
+   * This design is critical for nested structure reconciliation where a parent map/array
+   * reconciliation may trigger child reconciliations.
    */
   withReconcilingLock(fn: () => void): void {
     const previous = this.state.isReconciling;


### PR DESCRIPTION
This commit fixes critical and medium-priority issues identified during
a comprehensive architectural correctness audit of valtio-y.

## Critical Fix: Bootstrap TOCTOU Race Condition

**Issue:** Time-of-check-time-of-use race between emptiness check and
transaction could allow bootstrap to overwrite remote data arriving via
network provider between the check and the write.

**Fix:** Move emptiness check inside transaction for atomic check-and-set
(create-yjs-proxy.ts:131-157)

**Impact:** Prevents data loss in multi-client bootstrap scenarios

## Documentation Improvements

### Array Tail-Cursor Strategy Clarification
- Added detailed comments explaining tail-cursor behavior during mixed
  batch operations (array-apply.ts:203-237)
- Clarified that yArray.length is evaluated before each iteration,
  ensuring correct sequential appends
- Explained the three shouldAppend conditions and their rationale

### Delta Idempotency Guard Explanation
- Added comprehensive documentation for the idempotency check in delta
  reconciliation (reconciler.ts:362-375)
- Explained why structural reconciliation + delta application needs
  guards against double-application
- Clarified that this is NOT general deduplication but specifically
  prevents applying the same delta twice

### Reconciliation Lock Recursion Safety
- Documented that withReconcilingLock is recursion-safe
  (coordinator.ts:84-91)
- Added detailed explanation of save/restore pattern for nested
  reconciliation scenarios
- Clarified why this design is critical for nested structures

## Audit Findings Summary

The audit reviewed:
- Core synchronization logic and race conditions
- Yjs ↔ Valtio conversion correctness
- Memory leak prevention and cleanup
- Error handling and edge cases
- Test coverage for critical paths

Most identified issues were false positives where the code was already
correct but lacked clear documentation. The one true bug (bootstrap TOCTOU)
has been fixed. All other changes improve code clarity and maintainability.

**Testing:** Type checks pass, no formatting changes needed
**Files changed:** 4 files, +53 insertions, -20 deletions