### PR TITLE
feat(examples): migrate Minecraft example to Y-PartyServer

### DIFF
--- a/examples/03_minecraft/package.json
+++ b/examples/03_minecraft/package.json
@@ -7,12 +7,13 @@
     "@react-three/cannon": "latest",
     "@react-three/drei": "latest",
     "@react-three/fiber": "latest",
+    "partyserver": "^0.0.75",
     "react": "latest",
     "react-dom": "latest",
     "three": "latest",
     "valtio": "latest",
     "valtio-y": "workspace:*",
-    "y-webrtc": "latest",
+    "y-partyserver": "^0.0.51",
     "yjs": "latest"
   },
   "devDependencies": {
@@ -20,10 +21,13 @@
     "@types/react-dom": "latest",
     "@types/three": "latest",
     "typescript": "latest",
-    "vite": "latest"
+    "vite": "latest",
+    "wrangler": "^4.44.0"
   },
   "scripts": {
-    "dev": "PORT=4444 node node_modules/y-webrtc/bin/server.js & vite",
+    "dev": "bun run dev:y-party & bun run dev:app",
+    "dev:app": "vite",
+    "dev:y-party": "wrangler dev --config wrangler.y-party.jsonc --port 8788",
     "typecheck": "tsc --noEmit"
   }
 }

--- a/examples/03_minecraft/src/cube.tsx
+++ b/examples/03_minecraft/src/cube.tsx
@@ -8,16 +8,32 @@ import { useBox, type BoxProps, type Triplet } from "@react-three/cannon";
 import { useSnapshot } from "valtio";
 import * as Y from "yjs";
 import { createYjsProxy } from "valtio-y";
-import { WebrtcProvider } from "y-webrtc";
+import YProvider from "y-partyserver/provider";
 import dirt from "./assets/dirt.jpg";
 
 const ydoc = new Y.Doc();
 
-const provider = new WebrtcProvider("minecraft-valtio-y-demo-3", ydoc, {
-  signaling: ["ws://localhost:4444"],
+// Y-PartyServer configuration
+const getPartyHost = () => {
+  if (typeof window === "undefined") return "localhost:8788";
+  return window.location.hostname === "localhost"
+    ? "localhost:8788"
+    : window.location.host;
+};
+
+const ROOM_NAME = "minecraft-room";
+const PARTY_NAME = "y-doc-server"; // PartyServer converts YDocServer -> y-doc-server
+
+const host = getPartyHost();
+const provider = new YProvider(host, ROOM_NAME, ydoc, {
+  connect: true,
+  party: PARTY_NAME,
 });
 
-// (optional) attach provider event logs when debugging connectivity
+console.log("[valtio-y] Creating YProvider");
+console.log("[valtio-y] Host:", host);
+console.log("[valtio-y] Party:", PARTY_NAME);
+console.log("[valtio-y] Room:", ROOM_NAME);
 
 const { proxy: state, bootstrap } = createYjsProxy<{
   cubes?: [number, number, number][];

--- a/examples/03_minecraft/workers/y-party-worker.ts
+++ b/examples/03_minecraft/workers/y-party-worker.ts
@@ -1,0 +1,59 @@
+/**
+ * Standalone worker for Y-PartyServer
+ * Combines the YServer definition and fetch handler in one file
+ */
+
+import { routePartykitRequest } from "partyserver";
+import { YServer } from "y-partyserver";
+
+/**
+ * YDocServer is a durable object that hosts Yjs documents.
+ * YServer handles all routing, WebSocket upgrades, and synchronization automatically.
+ */
+export class YDocServer extends YServer {
+  // Configure periodic snapshots - saves every 2s or after 10s max
+  static callbackOptions = {
+    debounceWait: 2000, // Wait 2s after last update
+    debounceMaxWait: 10000, // Force save after 10s max
+    timeout: 5000,
+  };
+
+  // Load document state from Durable Object storage on initialization
+  async onLoad() {
+    const stored = await this.ctx.storage.get<Uint8Array>("document");
+    if (stored) {
+      const Y = await import("yjs");
+      Y.applyUpdate(this.document, stored);
+      console.log(`[YDocServer] Loaded snapshot: ${stored.byteLength} bytes`);
+    }
+  }
+
+  // Save document state to Durable Object storage (called automatically)
+  async onSave() {
+    const Y = await import("yjs");
+    const state = Y.encodeStateAsUpdate(this.document);
+    await this.ctx.storage.put("document", state);
+
+    // Store metadata for metrics
+    await this.ctx.storage.put("snapshot_size", state.byteLength);
+    await this.ctx.storage.put("snapshot_timestamp", Date.now());
+
+    console.log(`[YDocServer] Saved snapshot: ${state.byteLength} bytes`);
+  }
+}
+
+interface YPartyEnv extends Record<string, unknown> {
+  YDocServer: DurableObjectNamespace;
+}
+
+// Default fetch handler - routes requests to the YDocServer Durable Object
+export default {
+  async fetch(request: Request, env: YPartyEnv): Promise<Response> {
+    // Use PartyServer's routePartykitRequest to automatically route
+    // URLs like /parties/ydocserver/room-name to the YDocServer Durable Object
+    return (
+      (await routePartykitRequest(request, env)) ||
+      new Response("Not Found", { status: 404 })
+    );
+  },
+} satisfies ExportedHandler<YPartyEnv>;

--- a/examples/03_minecraft/wrangler.y-party.jsonc
+++ b/examples/03_minecraft/wrangler.y-party.jsonc
@@ -1,0 +1,31 @@
+/**
+ * Wrangler configuration for the Y-Party worker (Durable Objects)
+ * This worker runs standalone and clients connect to it via WebSocket
+ */
+{
+	"$schema": "node_modules/wrangler/config-schema.json",
+	"name": "minecraft-y-party-worker",
+	"compatibility_date": "2025-04-04",
+	"main": "./workers/y-party-worker.ts",
+	/**
+	 * Durable Objects
+	 */
+	"durable_objects": {
+		"bindings": [
+			{
+				"name": "YDocServer",
+				"class_name": "YDocServer",
+				"script_name": "minecraft-y-party-worker"
+			}
+		]
+	},
+	/**
+	 * Migrations - required for Durable Objects
+	 */
+	"migrations": [
+		{
+			"tag": "v1",
+			"new_classes": ["YDocServer"]
+		}
+	]
+}


### PR DESCRIPTION
Replaces y-webrtc with y-partyserver for the Minecraft example.

Changes:
- Create wrangler.y-party.jsonc configuration for Y-PartyServer worker
- Add workers/y-party-worker.ts implementing YDocServer with Durable Objects
- Update dependencies: replace y-webrtc with y-partyserver and partyserver
- Update cube.tsx to use YProvider from y-partyserver/provider
- Update dev scripts to run Y-PartyServer worker on port 8788
- Remove dependency on local WebRTC signaling server

The setup now matches the y-partyserver-todo example pattern.