### PR TITLE
chore(ci): fix npm publish race condition by using pure changesets workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,8 +42,8 @@ jobs:
         with:
           # This script runs changeset version with bun update to fix workspace:* refs
           version: bun run version
-          # This script publishes packages to npm
-          publish: bun run release
+          # Changesets automatically publishes packages when versions are merged
+          # It will call the "publish" script in each package's package.json
           title: "chore(release): version packages"
           commit: "chore(release): version packages"
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,7 +241,7 @@ Closes #42
 
 ### Release Workflow
 
-This project uses **Changesets** with **Turbo** to manage versioning and releases, providing explicit control over changelogs.
+This project uses **Changesets** to manage versioning and releases, providing explicit control over changelogs.
 
 **How it works:**
 
@@ -273,10 +273,9 @@ This project uses **Changesets** with **Turbo** to manage versioning and release
 
 4. **Merge to publish** - When you merge the Version Packages PR:
    - The workflow runs all quality checks (typecheck, lint, test, build)
-   - Runs: `bun run release` → `turbo run publish --filter='valtio-*' && changeset tag`
-   - Turbo runs the `publish` script in each `valtio-*` package
-   - Each package publishes with: `npm publish --access public --provenance`
-   - Git tags are created for published versions
+   - Changesets automatically detects changed packages and publishes them to npm
+   - Runs the `publish` script in each changed package: `npm publish --access public --provenance`
+   - Git tags are created automatically for published versions
 
 **For AI agents:**
 
@@ -342,16 +341,15 @@ To make a new package publishable:
    }
    ```
 
-2. Ensure the package name matches `valtio-*` pattern
-3. Turbo will automatically discover and publish it in the correct order
+2. Add the package to the workspace in root `package.json`
+3. Changesets will automatically discover and publish it when you create a changeset for it
 
 **Technical details:**
 
 - **Root scripts**:
   - `version`: `changeset version && bun update` (updates versions + fixes Bun lockfile)
-  - `release`: `turbo run publish --filter='valtio-*' && changeset tag` (publishes packages + creates tags)
 - **Bun workaround**: `bun update` after `changeset version` is required because changesets doesn't natively support Bun workspaces. This resolves `workspace:*` references in the lockfile.
-- **Turbo filter**: `--filter='valtio-*'` ensures only `valtio-y` and future `valtio-*` packages are published, never examples
+- **Publishing**: Changesets automatically handles publishing and git tagging when the version PR is merged. It only publishes packages that have changesets and are not marked as `private: true`.
 
 **Version bumping rules:**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,7 +241,7 @@ Closes #42
 
 ### Release Workflow
 
-This project uses **Changesets** with **Turbo** to manage versioning and releases, providing explicit control over changelogs.
+This project uses **Changesets** to manage versioning and releases, providing explicit control over changelogs.
 
 **How it works:**
 
@@ -273,10 +273,9 @@ This project uses **Changesets** with **Turbo** to manage versioning and release
 
 4. **Merge to publish** - When you merge the Version Packages PR:
    - The workflow runs all quality checks (typecheck, lint, test, build)
-   - Runs: `bun run release` → `turbo run publish --filter='valtio-*' && changeset tag`
-   - Turbo runs the `publish` script in each `valtio-*` package
-   - Each package publishes with: `npm publish --access public --provenance`
-   - Git tags are created for published versions
+   - Changesets automatically detects changed packages and publishes them to npm
+   - Runs the `publish` script in each changed package: `npm publish --access public --provenance`
+   - Git tags are created automatically for published versions
 
 **For AI agents:**
 
@@ -342,16 +341,15 @@ To make a new package publishable:
    }
    ```
 
-2. Ensure the package name matches `valtio-*` pattern
-3. Turbo will automatically discover and publish it in the correct order
+2. Add the package to the workspace in root `package.json`
+3. Changesets will automatically discover and publish it when you create a changeset for it
 
 **Technical details:**
 
 - **Root scripts**:
   - `version`: `changeset version && bun update` (updates versions + fixes Bun lockfile)
-  - `release`: `turbo run publish --filter='valtio-*' && changeset tag` (publishes packages + creates tags)
 - **Bun workaround**: `bun update` after `changeset version` is required because changesets doesn't natively support Bun workspaces. This resolves `workspace:*` references in the lockfile.
-- **Turbo filter**: `--filter='valtio-*'` ensures only `valtio-y` and future `valtio-*` packages are published, never examples
+- **Publishing**: Changesets automatically handles publishing and git tagging when the version PR is merged. It only publishes packages that have changesets and are not marked as `private: true`.
 
 **Version bumping rules:**
 

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
     "lint:fix": "oxlint --type-aware --fix .",
     "format": "bun oxfmt .",
     "check": "bun run format && bun run lint:fix",
-    "version": "changeset version && bun update",
-    "release": "turbo run publish --filter='valtio-*' && changeset tag"
+    "version": "changeset version && bun update"
   },
   "private": true,
   "keywords": [],

--- a/valtio-y/package.json
+++ b/valtio-y/package.json
@@ -1,7 +1,7 @@
 {
   "name": "valtio-y",
   "description": "Collaborative Valtio state",
-  "version": "1.0.5",
+  "version": "1.0.7",
   "type": "module",
   "author": "Alex Gogl",
   "repository": {
@@ -35,7 +35,7 @@
     "test": "bun vitest",
     "bench": "bun vitest bench --config vitest.bench.config.ts",
     "typecheck": "bun tsc -b --emitDeclarationOnly",
-    "publish": "npm publish --access public"
+    "publish": "npm publish --access public --provenance"
   },
   "keywords": [
     "valtio",


### PR DESCRIPTION
## Summary

Fixes the npm publish race condition where packages were being published twice, causing version conflict errors.

**Root cause:** Both the changesets action and our custom Turbo-based publish script were attempting to publish simultaneously when the version PR was merged.

**Solution:** Migrate to pure changesets workflow - let changesets handle everything automatically.

## Changes

- Remove `publish` parameter from changesets action in `.github/workflows/release.yml`
- Remove custom `release` script from root `package.json`
- Add `--provenance` flag to `valtio-y/package.json` publish script
- Update documentation (`CLAUDE.md`, `AGENTS.md`) to reflect new workflow

## How it works now

1. Create changeset: `bun changeset`
2. Merge to main → Version PR auto-created
3. Merge version PR → Changesets automatically publishes to npm

Only one publish mechanism runs, eliminating race conditions.

## Test plan

- [x] Workflow file validates
- [x] Documentation updated
- [ ] Verify next release publishes cleanly (will test on merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)