### PR TITLE
chore(ci): enable GitHub releases on publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,9 +52,9 @@ jobs:
           # This script runs changeset version with bun update to fix workspace:* refs
           version: bun run version
           # This publishes packages when the version PR is merged
-          publish: bun changeset publish
-          # Changesets automatically publishes packages when versions are merged
-          # It will call the "publish" script in each package's package.json
+          publish: changeset publish
+          # Create GitHub releases automatically (includes tag creation)
+          createGithubReleases: true
           title: "chore(release): version packages"
           commit: "chore(release): version packages"
         env:


### PR DESCRIPTION
## Summary

Enable automatic GitHub release creation when packages are published to npm via the changesets workflow.

## Changes

- Changed `publish: bun changeset publish` to `publish: changeset publish` to ensure proper output detection by the changesets action
- Added `createGithubReleases: true` to explicitly enable GitHub release creation
- Updated comments to reflect the new behavior

## Why

Previously, packages were being published to npm successfully, but:
- No git tags were being created
- No GitHub releases were being generated

This was because the `bun` prefix in the publish command may have interfered with the changesets action's output detection. The action looks for "New tag:" in the publish output to trigger release creation.

## What happens next

When a "Version Packages" PR is merged, the workflow will now:
1. Publish packages to npm (as before)
2. Create git tags (e.g., `valtio-y@1.2.3`)
3. Create GitHub releases with changelog content from changesets

## Testing

This will be verified on the next package publish.