### PR TITLE
chore(repo): cleanup stale comments and outdated documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -431,7 +431,7 @@ TypeScript monorepo using **Bun** (package manager) for a library that syncs **V
 ### Folder Structure
 
 ```text
-/Users/alex/code/valtio-yjs/
+/Users/alex/code/valtio-y/
 
 ├── valtio-y/            # Main package
 │   ├── src/             # Source code

--- a/valtio-y/src/bridge/valtio-bridge.ts
+++ b/valtio-y/src/bridge/valtio-bridge.ts
@@ -8,7 +8,6 @@
 // - Lazily create nested controllers when a Y value is another Y type.
 import * as Y from "yjs";
 import { proxy, subscribe } from "valtio/vanilla";
-// import removed: origin tagging handled by context scheduler
 
 import type { YSharedContainer } from "../core/yjs-types";
 import type { ValtioYjsCoordinator } from "../core/coordinator";
@@ -24,8 +23,6 @@ import {
   rollbackArrayChanges,
   rollbackMapChanges,
 } from "./controller-helpers";
-
-// All caches are moved into SynchronizationContext
 
 // Subscribe to a Valtio array proxy and translate top-level index operations
 // into minimal Y.Array operations.

--- a/valtio-y/src/core/coordinator.ts
+++ b/valtio-y/src/core/coordinator.ts
@@ -51,17 +51,14 @@ export class ValtioYjsCoordinator {
     // This eliminates the need for setter injection
     const applyFunctions: ApplyFunctions = {
       applyMapDeletes: (deletes) => {
-        // Current signature: applyMapDeletes(mapDeletes, log)
         applyMapDeletes(deletes, this.logger);
       },
 
       applyMapSets: (sets, queue, withLock) => {
-        // Updated signature: applyMapSets(mapSets, postQueue, coordinator, withReconcilingLock)
         applyMapSets(sets, queue, this, withLock);
       },
 
       applyArrayOperations: (sets, deletes, replaces, queue, withLock) => {
-        // Updated signature: applyArrayOperations(coordinator, arraySets, arrayDeletes, arrayReplaces, postQueue, withReconcilingLock)
         applyArrayOperations(this, sets, deletes, replaces, queue, withLock);
       },
 

--- a/valtio-y/src/reconcile/reconciler.ts
+++ b/valtio-y/src/reconcile/reconciler.ts
@@ -78,7 +78,7 @@ export function findRemovedControllers(
 //   proxies exist (materialized) and match the Y tree shape.
 // - No deepEqual. Only add missing keys, remove extra keys, and create
 //   nested controllers for Y types as needed.
-// - Uses runWithoutValtioReflection to avoid reflecting these changes back
+// - Uses withReconcilingLock to avoid reflecting these changes back
 //   to Yjs.
 /**
  * Reconciles the structure of a Valtio proxy to match its underlying Y.Map.


### PR DESCRIPTION
Removes historical comments about refactors (e.g., 'All caches are moved into SynchronizationState') and corrects outdated documentation regarding file structure and function names. No logic changes.