### PR TITLE
fix(ci): use bunx for changeset publish command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
           # This script runs changeset version with bun update to fix workspace:* refs
           version: bun run version
           # This publishes packages when the version PR is merged
-          publish: changeset publish
+          publish: bunx changeset publish
           # Create GitHub releases automatically (includes tag creation)
           createGithubReleases: true
           title: "chore(release): version packages"


### PR DESCRIPTION
## Summary
- Fix the release workflow's publish step which fails because `changeset` binary isn't found in PATH when using `bun install --ignore-scripts`
- Changed `changeset publish` to `bunx changeset publish`

## Test plan
- [ ] Merge this PR → push to main triggers Release workflow → changesets detects no pending changesets (already consumed) → no publish needed, but the command should resolve correctly
- [ ] Next time a changeset version PR is merged, the publish step should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)