### PR TITLE
chore(repo): add vendor to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules
 .DS_Store
 .turbo
 .wrangler
+vendor


### PR DESCRIPTION
## Summary
- Add `vendor/` to `.gitignore` to prevent accidentally committing vendored reference code

🤖 Generated with [Claude Code](https://claude.com/claude-code)