### PR TITLE
fix(examples): stop idle ydoc alarm loops

### DIFF
--- a/examples/minecraft/worker/index.ts
+++ b/examples/minecraft/worker/index.ts
@@ -96,6 +96,16 @@ export class YDocServer extends YServer<Env> {
     hibernate: true,
   };
 
+  private hasActiveConnections(): boolean {
+    return this.ctx
+      .getWebSockets()
+      .some((socket) => socket.readyState === WebSocket.OPEN);
+  }
+
+  private async scheduleNextCleanup(): Promise<void> {
+    await this.ctx.storage.setAlarm(Date.now() + CLEANUP_INTERVAL_MS);
+  }
+
   /**
    * Initialize document with initial cubes if empty
    * Called once when a client connects to the server
@@ -106,9 +116,8 @@ export class YDocServer extends YServer<Env> {
       this.createInitialCubes(sharedState);
     }
 
-    // Schedule the first alarm to clean the room
-    const now = Date.now();
-    await this.ctx.storage.setAlarm(now + CLEANUP_INTERVAL_MS);
+    // Schedule the first alarm for a newly opened room.
+    await this.scheduleNextCleanup();
   }
 
   onError(error: unknown): void {
@@ -119,14 +128,18 @@ export class YDocServer extends YServer<Env> {
    * Alarm handler that resets the room and creates fresh initial cubes
    * This is called automatically by the Durable Objects runtime
    */
-  async alarm(): Promise<void> {
+  async onAlarm(): Promise<void> {
+    if (!this.hasActiveConnections()) {
+      await this.ctx.storage.deleteAlarm();
+      return;
+    }
+
     const sharedState = this.document.getMap("map");
     // Create fresh initial cubes
     this.createInitialCubes(sharedState);
 
     // Schedule the next alarm
-    const now = Date.now();
-    await this.ctx.storage.setAlarm(now + CLEANUP_INTERVAL_MS);
+    await this.scheduleNextCleanup();
   }
 
   /**

--- a/examples/simple/worker/index.ts
+++ b/examples/simple/worker/index.ts
@@ -99,6 +99,16 @@ export class YDocServer extends YServer<Env> {
     hibernate: true,
   };
 
+  private hasActiveConnections(): boolean {
+    return this.ctx
+      .getWebSockets()
+      .some((socket) => socket.readyState === WebSocket.OPEN);
+  }
+
+  private async scheduleNextCleanup(): Promise<void> {
+    await this.ctx.storage.setAlarm(Date.now() + CLEANUP_INTERVAL_MS);
+  }
+
   /**
    * Initialize document with sample todos if empty
    * Called once when a client connects to the server
@@ -109,9 +119,8 @@ export class YDocServer extends YServer<Env> {
       this.createInitialTodos(sharedState);
     }
 
-    // Schedule the first alarm to clean the room
-    const now = Date.now();
-    await this.ctx.storage.setAlarm(now + CLEANUP_INTERVAL_MS);
+    // Schedule the first alarm for a newly opened room.
+    await this.scheduleNextCleanup();
   }
 
   onError(error: unknown): void {
@@ -122,14 +131,18 @@ export class YDocServer extends YServer<Env> {
    * Alarm handler that cleans the room and creates fresh todos
    * This is called automatically by the Durable Objects runtime
    */
-  async alarm(): Promise<void> {
+  async onAlarm(): Promise<void> {
+    if (!this.hasActiveConnections()) {
+      await this.ctx.storage.deleteAlarm();
+      return;
+    }
+
     const sharedState = this.document.getMap("root");
     // Create fresh initial todos
     this.createInitialTodos(sharedState);
 
     // Schedule the next alarm
-    const now = Date.now();
-    await this.ctx.storage.setAlarm(now + CLEANUP_INTERVAL_MS);
+    await this.scheduleNextCleanup();
   }
 
   /**

--- a/examples/sticky-notes/worker/index.ts
+++ b/examples/sticky-notes/worker/index.ts
@@ -19,6 +19,16 @@ export class YDocServer extends YServer<Env> {
     hibernate: true,
   };
 
+  private hasActiveConnections(): boolean {
+    return this.ctx
+      .getWebSockets()
+      .some((socket) => socket.readyState === WebSocket.OPEN);
+  }
+
+  private async scheduleNextCleanup(): Promise<void> {
+    await this.ctx.storage.setAlarm(Date.now() + CLEANUP_INTERVAL_MS);
+  }
+
   /**
    * Create fresh initial notes in the shared state
    * This is called on initial load and every 30 minutes via alarm
@@ -142,22 +152,25 @@ export class YDocServer extends YServer<Env> {
       this.createInitialNotes();
     }
 
-    // Schedule the first alarm to clean the room
-    const now = Date.now();
-    await this.ctx.storage.setAlarm(now + CLEANUP_INTERVAL_MS);
+    // Schedule the first alarm for a newly opened room.
+    await this.scheduleNextCleanup();
   }
 
   /**
    * Alarm handler that cleans the room and creates fresh notes
    * This is called automatically by the Durable Objects runtime
    */
-  async alarm(): Promise<void> {
+  async onAlarm(): Promise<void> {
+    if (!this.hasActiveConnections()) {
+      await this.ctx.storage.deleteAlarm();
+      return;
+    }
+
     // Create fresh initial notes
     this.createInitialNotes();
 
     // Schedule the next alarm
-    const now = Date.now();
-    await this.ctx.storage.setAlarm(now + CLEANUP_INTERVAL_MS);
+    await this.scheduleNextCleanup();
   }
 }
 

--- a/examples/todos/worker/index.ts
+++ b/examples/todos/worker/index.ts
@@ -103,6 +103,16 @@ export class YDocServer extends YServer<Env> {
     hibernate: true,
   };
 
+  private hasActiveConnections(): boolean {
+    return this.ctx
+      .getWebSockets()
+      .some((socket) => socket.readyState === WebSocket.OPEN);
+  }
+
+  private async scheduleNextCleanup(): Promise<void> {
+    await this.ctx.storage.setAlarm(Date.now() + CLEANUP_INTERVAL_MS);
+  }
+
   /**
    * Initialize document with sample todos if empty
    * Called once when a client connects to the server
@@ -113,9 +123,8 @@ export class YDocServer extends YServer<Env> {
       this.createInitialTodos(sharedState);
     }
 
-    // Schedule the first alarm to clean the room
-    const now = Date.now();
-    await this.ctx.storage.setAlarm(now + CLEANUP_INTERVAL_MS);
+    // Schedule the first alarm for a newly opened room.
+    await this.scheduleNextCleanup();
   }
 
   onError(error: unknown): void {
@@ -126,14 +135,18 @@ export class YDocServer extends YServer<Env> {
    * Alarm handler that cleans the room and creates fresh todos
    * This is called automatically by the Durable Objects runtime
    */
-  async alarm(): Promise<void> {
+  async onAlarm(): Promise<void> {
+    if (!this.hasActiveConnections()) {
+      await this.ctx.storage.deleteAlarm();
+      return;
+    }
+
     const sharedState = this.document.getMap("root");
     // Create fresh initial todos
     this.createInitialTodos(sharedState);
 
     // Schedule the next alarm
-    const now = Date.now();
-    await this.ctx.storage.setAlarm(now + CLEANUP_INTERVAL_MS);
+    await this.scheduleNextCleanup();
   }
 
   /**

--- a/examples/whiteboard/worker/app.ts
+++ b/examples/whiteboard/worker/app.ts
@@ -14,6 +14,16 @@ export class YDocServer extends YServer<Env> {
     hibernate: true,
   };
 
+  private hasActiveConnections(): boolean {
+    return this.ctx
+      .getWebSockets()
+      .some((socket) => socket.readyState === WebSocket.OPEN);
+  }
+
+  private async scheduleNextCleanup(): Promise<void> {
+    await this.ctx.storage.setAlarm(Date.now() + CLEANUP_INTERVAL_MS);
+  }
+
   // Configure periodic snapshots - saves every 2s or after 10s max
   static callbackOptions = {
     debounceWait: 2000, // Wait 2s after last update
@@ -54,9 +64,8 @@ export class YDocServer extends YServer<Env> {
       this.createInitialShapes();
     }
 
-    // Schedule the first alarm to clean the room
-    const now = Date.now();
-    await this.ctx.storage.setAlarm(now + CLEANUP_INTERVAL_MS);
+    // Schedule the first alarm for a newly opened room
+    await this.scheduleNextCleanup();
   }
 
   // Save document state to Durable Object storage (called automatically)
@@ -75,13 +84,17 @@ export class YDocServer extends YServer<Env> {
    * Alarm handler that resets the room to empty state
    * This is called automatically by the Durable Objects runtime
    */
-  async alarm(): Promise<void> {
+  async onAlarm(): Promise<void> {
+    if (!this.hasActiveConnections()) {
+      await this.ctx.storage.deleteAlarm();
+      return;
+    }
+
     // Reset to empty state
     this.createInitialShapes();
 
     // Schedule the next alarm
-    const now = Date.now();
-    await this.ctx.storage.setAlarm(now + CLEANUP_INTERVAL_MS);
+    await this.scheduleNextCleanup();
   }
 }
 


### PR DESCRIPTION
## Summary
- stop example YDocServer alarms from rescheduling when no WebSockets are connected
- use the PartyServer onAlarm lifecycle hook instead of overriding alarm directly
- keep the scheduled demo reset behavior for active rooms

## Verification
- bun oxfmt examples/sticky-notes/worker/index.ts examples/todos/worker/index.ts examples/simple/worker/index.ts examples/minecraft/worker/index.ts examples/whiteboard/worker/app.ts
- bun tsc -p examples/sticky-notes/tsconfig.worker.json --noEmit
- bun tsc -p examples/todos/tsconfig.worker.json --noEmit
- bun tsc -p examples/simple/tsconfig.worker.json --noEmit
- bun tsc -p examples/minecraft/tsconfig.worker.json --noEmit
- bun tsc -p examples/whiteboard/tsconfig.worker.json --noEmit

## Deployments
- valtio-y-stickynotes: ddbba555-8cf2-4d92-84bd-642de05375cb
- valtio-y-todos: 67ff5141-21f2-4c71-b668-023d17fb5c75
- valtio-y-simple: c27dd509-352e-4515-b030-8e091f6c756d
- valtio-y-minecraft: f76457f8-7cad-4650-aff6-1aa9c6649825
- valtio-y-whiteboard: d59bcbcb-c1b4-42c0-af32-8649fe0f8b3e